### PR TITLE
feat: add device bandwidth profiles and improve recommendation confidence scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ coverage/
 **/Generated.xcconfig
 **/Pods/
 **/Flutter/ephemeral/
+
+# Droid-generated files
+.factory/skills/ship/
+.worktrees/
+Straemsize_OpenIssues_Report.html

--- a/packages/core/lib/src/models.dart
+++ b/packages/core/lib/src/models.dart
@@ -11,6 +11,52 @@ enum DeviceCategory {
 
   const DeviceCategory(this.label);
   final String label;
+
+  DeviceBandwidthProfile get bandwidthProfile {
+    switch (this) {
+      case DeviceCategory.tv:
+        return const DeviceBandwidthProfile(minMbps: 5, typicalMbps: 25, maxMbps: 100);
+      case DeviceCategory.phone:
+        return const DeviceBandwidthProfile(minMbps: 2, typicalMbps: 10, maxMbps: 50);
+      case DeviceCategory.tablet:
+        return const DeviceBandwidthProfile(minMbps: 2, typicalMbps: 10, maxMbps: 50);
+      case DeviceCategory.laptop:
+        return const DeviceBandwidthProfile(minMbps: 5, typicalMbps: 25, maxMbps: 100);
+      case DeviceCategory.console:
+        return const DeviceBandwidthProfile(minMbps: 5, typicalMbps: 25, maxMbps: 100);
+      case DeviceCategory.camera:
+        return const DeviceBandwidthProfile(minMbps: 2, typicalMbps: 5, maxMbps: 20);
+      case DeviceCategory.smartHome:
+        return const DeviceBandwidthProfile(minMbps: 1, typicalMbps: 2, maxMbps: 10);
+      case DeviceCategory.nas:
+        return const DeviceBandwidthProfile(minMbps: 5, typicalMbps: 10, maxMbps: 50);
+      case DeviceCategory.unknown:
+        return const DeviceBandwidthProfile(minMbps: 1, typicalMbps: 3, maxMbps: 10);
+    }
+  }
+}
+
+class DeviceBandwidthProfile {
+  const DeviceBandwidthProfile({
+    required this.minMbps,
+    required this.typicalMbps,
+    required this.maxMbps,
+  });
+
+  final int minMbps;
+  final int typicalMbps;
+  final int maxMbps;
+
+  int mbpsForConfidence(ConfidenceScore confidence) {
+    switch (confidence) {
+      case ConfidenceScore.high:
+        return typicalMbps;
+      case ConfidenceScore.medium:
+        return ((minMbps + typicalMbps) / 2).round();
+      case ConfidenceScore.low:
+        return minMbps;
+    }
+  }
 }
 
 enum ConfidenceScore { low, medium, high }

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -14,13 +14,14 @@ class RecommendationEngine {
         (scenario.remoteWorkers * 10) +
         (scenario.onlineGamers * 3) +
         _downloadHabitLoad(scenario.largeDownloadHabit) +
-        _deviceBaselineDownload(detectedCounts) +
-        _homeProfileDownload(scenario.homeProfile);
+        _deviceBaselineDownloadWeighted(scenario.devices, detectedCounts) +
+        _homeProfileDownload(scenario.homeProfile) +
+        _concurrencyOverhead(scenario);
 
     final uploadDemand =
         (scenario.simultaneousVideoCalls * 4) +
         (scenario.remoteWorkers * 5) +
-        (scenario.securityCameraCount * 3) +
+        _cameraUploadLoad(scenario.devices, scenario.securityCameraCount) +
         (scenario.cloudBackupEnabled ? 20 : 0) +
         (detectedCounts[DeviceCategory.nas] ?? 0) * 5 +
         _homeProfileUpload(scenario.homeProfile);
@@ -38,14 +39,28 @@ class RecommendationEngine {
     );
   }
 
-  int _deviceBaselineDownload(Map<DeviceCategory, int> counts) {
-    return (counts[DeviceCategory.tv] ?? 0) * 5 +
-        (counts[DeviceCategory.laptop] ?? 0) * 3 +
-        (counts[DeviceCategory.phone] ?? 0) * 2 +
-        (counts[DeviceCategory.tablet] ?? 0) * 2 +
-        (counts[DeviceCategory.console] ?? 0) * 3 +
-        (counts[DeviceCategory.smartHome] ?? 0) +
-        (counts[DeviceCategory.nas] ?? 0) * 10;
+  int _deviceBaselineDownloadWeighted(
+    List<DetectedDevice> devices,
+    Map<DeviceCategory, int> counts,
+  ) {
+    final avgConfidenceByCategory = <DeviceCategory, ConfidenceScore>{};
+    for (final device in devices) {
+      if (device.category == DeviceCategory.unknown) continue;
+      final existing = avgConfidenceByCategory[device.category];
+      if (existing == null || device.confidence.index > existing.index) {
+        avgConfidenceByCategory[device.category] = device.confidence;
+      }
+    }
+
+    int total = 0;
+    for (final entry in counts.entries) {
+      final category = entry.key;
+      final count = entry.value;
+      final profile = category.bandwidthProfile;
+      final confidence = avgConfidenceByCategory[category] ?? ConfidenceScore.medium;
+      total += profile.mbpsForConfidence(confidence) * count;
+    }
+    return total;
   }
 
   int _downloadHabitLoad(LargeDownloadHabit habit) {
@@ -81,6 +96,26 @@ class RecommendationEngine {
     }
   }
 
+  int _concurrencyOverhead(HouseholdScenario scenario) {
+    final activeStreams = scenario.simultaneous4kStreams +
+        scenario.simultaneousHdStreams +
+        scenario.simultaneousVideoCalls +
+        scenario.remoteWorkers +
+        scenario.onlineGamers;
+    if (activeStreams <= 2) return 0;
+    if (activeStreams <= 5) return 10;
+    if (activeStreams <= 8) return 20;
+    return 30;
+  }
+
+  int _cameraUploadLoad(List<DetectedDevice> devices, int declaredCount) {
+    final detectedCameras = devices.where((d) => d.category == DeviceCategory.camera).length;
+    final totalCameras = detectedCameras > 0 ? detectedCameras : declaredCount;
+    if (totalCameras == 0) return 0;
+    final profile = DeviceCategory.camera.bandwidthProfile;
+    return profile.mbpsForConfidence(ConfidenceScore.medium) * totalCameras;
+  }
+
   int _withHeadroom(int value) => (value * 1.3).ceil();
 
   int _normalizeDownload(int value) {
@@ -108,22 +143,47 @@ class RecommendationEngine {
 
   List<String> _buildReasons(HouseholdScenario scenario, Map<DeviceCategory, int> counts) {
     return [
-      '${scenario.simultaneous4kStreams} simultaneous 4K streams',
-      '${scenario.simultaneousVideoCalls} live video calls',
-      if (scenario.remoteWorkers > 0) '${scenario.remoteWorkers} remote workers',
-      if (scenario.onlineGamers > 0) '${scenario.onlineGamers} online gamers sharing the connection',
-      if (scenario.securityCameraCount > 0) '${scenario.securityCameraCount} security cameras pushing upload traffic',
-      if (scenario.cloudBackupEnabled) 'cloud backup headroom included',
-      '${scenario.devices.length} visible devices detected on the local network',
-      if ((counts[DeviceCategory.tv] ?? 0) > 0) '${counts[DeviceCategory.tv]} TVs or streamers discovered',
+      '${scenario.simultaneous4kStreams} simultaneous 4K stream${scenario.simultaneous4kStreams != 1 ? "s" : ""} (25 Mbps each)',
+      if (scenario.simultaneousVideoCalls > 0)
+        '${scenario.simultaneousVideoCalls} live video call${scenario.simultaneousVideoCalls != 1 ? "s" : ""} (6 Mbps down / 4 Mbps up)',
+      if (scenario.remoteWorkers > 0)
+        '${scenario.remoteWorkers} remote worker${scenario.remoteWorkers != 1 ? "s" : ""} (10 Mbps each)',
+      if (scenario.onlineGamers > 0)
+        '${scenario.onlineGamers} online gamer${scenario.onlineGamers != 1 ? "s" : ""} (3 Mbps each)',
+      if (scenario.securityCameraCount > 0 || (counts[DeviceCategory.camera] ?? 0) > 0)
+        '${counts[DeviceCategory.camera] ?? scenario.securityCameraCount} security camera${(counts[DeviceCategory.camera] ?? scenario.securityCameraCount) != 1 ? "s" : ""} uploading footage',
+      if (scenario.cloudBackupEnabled)
+        'Cloud backup headroom included (20 Mbps)',
+      '${scenario.devices.length} device${scenario.devices.length != 1 ? "s" : ""} on the network',
+      if ((counts[DeviceCategory.tv] ?? 0) > 0)
+        '${counts[DeviceCategory.tv]} TV/streamer${(counts[DeviceCategory.tv]) != 1 ? "s" : ""} (typical ${DeviceCategory.tv.bandwidthProfile.typicalMbps} Mbps each)',
+      if (scenario.largeDownloadHabit != LargeDownloadHabit.rarely)
+        '${scenario.largeDownloadHabit.label} large downloads (+${_downloadHabitLoad(scenario.largeDownloadHabit)} Mbps)',
+      if (_concurrencyOverhead(scenario) > 0)
+        'Concurrency overhead: ${_concurrencyOverhead(scenario)} Mbps for ${scenario.simultaneous4kStreams + scenario.simultaneousHdStreams + scenario.simultaneousVideoCalls + scenario.remoteWorkers + scenario.onlineGamers} simultaneous active streams',
     ];
   }
 
   ConfidenceScore _confidenceFor(HouseholdScenario scenario) {
-    if (scenario.devices.length >= 6 && scenario.simultaneous4kStreams > 0) {
+    final detectedCounts = <DeviceCategory, int>{};
+    for (final device in scenario.devices) {
+      detectedCounts.update(device.category, (v) => v + 1, ifAbsent: () => 1);
+    }
+
+    final highConfidenceDevices = scenario.devices.where((d) => d.confidence == ConfidenceScore.high).length;
+    final totalDevices = scenario.devices.length;
+    final ratio = totalDevices > 0 ? highConfidenceDevices / totalDevices : 0.0;
+
+    final hasExplicitUsage = scenario.simultaneous4kStreams > 0 ||
+        scenario.simultaneousHdStreams > 0 ||
+        scenario.simultaneousVideoCalls > 0 ||
+        scenario.remoteWorkers > 0 ||
+        scenario.onlineGamers > 0;
+
+    if (totalDevices >= 4 && ratio >= 0.6 && hasExplicitUsage) {
       return ConfidenceScore.high;
     }
-    if (scenario.devices.isNotEmpty) {
+    if (totalDevices >= 1 || hasExplicitUsage) {
       return ConfidenceScore.medium;
     }
     return ConfidenceScore.low;

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -3,14 +3,10 @@ import 'models.dart';
 class RecommendationEngine {
   PlanRecommendation buildRecommendation(HouseholdScenario scenario) {
     final detectedCounts = <DeviceCategory, int>{};
-    for (final device in scenario.devices) {
-      if (device.category == DeviceCategory.unknown) continue;
-      detectedCounts.update(device.category, (value) => value + 1, ifAbsent: () => 1);
-    }
-
     final maxConfidenceByCategory = <DeviceCategory, ConfidenceScore>{};
     for (final device in scenario.devices) {
       if (device.category == DeviceCategory.unknown) continue;
+      detectedCounts.update(device.category, (value) => value + 1, ifAbsent: () => 1);
       final existing = maxConfidenceByCategory[device.category];
       if (existing == null || device.confidence.index > existing.index) {
         maxConfidenceByCategory[device.category] = device.confidence;
@@ -174,7 +170,7 @@ class RecommendationEngine {
       if (effectiveCameraCount > 0)
         '$effectiveCameraCount security camera${effectiveCameraCount != 1 ? "s" : ""} uploading footage',
       if (scenario.cloudBackupEnabled)
-        'Cloud backup headroom included (20 Mbps)',
+        'Cloud backup upload headroom included (20 Mbps)',
       '${scenario.devices.length} device${scenario.devices.length != 1 ? "s" : ""} on the network',
       if ((counts[DeviceCategory.tv] ?? 0) > 0)
         '${counts[DeviceCategory.tv]} TV/streamer${(counts[DeviceCategory.tv]) != 1 ? "s" : ""} (${_confidenceLabel(maxConfidenceByCategory[DeviceCategory.tv])} ${DeviceCategory.tv.bandwidthProfile.mbpsForConfidence(maxConfidenceByCategory[DeviceCategory.tv] ?? ConfidenceScore.medium)} Mbps each)',
@@ -188,7 +184,7 @@ class RecommendationEngine {
   String _confidenceLabel(ConfidenceScore? confidence) {
     switch (confidence ?? ConfidenceScore.medium) {
       case ConfidenceScore.high:
-        return 'up to';
+        return '~';
       case ConfidenceScore.medium:
         return '~';
       case ConfidenceScore.low:

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -4,6 +4,7 @@ class RecommendationEngine {
   PlanRecommendation buildRecommendation(HouseholdScenario scenario) {
     final detectedCounts = <DeviceCategory, int>{};
     for (final device in scenario.devices) {
+      if (device.category == DeviceCategory.unknown) continue;
       detectedCounts.update(device.category, (value) => value + 1, ifAbsent: () => 1);
     }
 
@@ -43,12 +44,12 @@ class RecommendationEngine {
     List<DetectedDevice> devices,
     Map<DeviceCategory, int> counts,
   ) {
-    final avgConfidenceByCategory = <DeviceCategory, ConfidenceScore>{};
+    final maxConfidenceByCategory = <DeviceCategory, ConfidenceScore>{};
     for (final device in devices) {
       if (device.category == DeviceCategory.unknown) continue;
-      final existing = avgConfidenceByCategory[device.category];
+      final existing = maxConfidenceByCategory[device.category];
       if (existing == null || device.confidence.index > existing.index) {
-        avgConfidenceByCategory[device.category] = device.confidence;
+        maxConfidenceByCategory[device.category] = device.confidence;
       }
     }
 
@@ -57,7 +58,7 @@ class RecommendationEngine {
       final category = entry.key;
       final count = entry.value;
       final profile = category.bandwidthProfile;
-      final confidence = avgConfidenceByCategory[category] ?? ConfidenceScore.medium;
+      final confidence = maxConfidenceByCategory[category] ?? ConfidenceScore.medium;
       total += profile.mbpsForConfidence(confidence) * count;
     }
     return total;
@@ -142,8 +143,11 @@ class RecommendationEngine {
   }
 
   List<String> _buildReasons(HouseholdScenario scenario, Map<DeviceCategory, int> counts) {
+    final concurrencyOverhead = _concurrencyOverhead(scenario);
     return [
       '${scenario.simultaneous4kStreams} simultaneous 4K stream${scenario.simultaneous4kStreams != 1 ? "s" : ""} (25 Mbps each)',
+      if (scenario.simultaneousHdStreams > 0)
+        '${scenario.simultaneousHdStreams} simultaneous HD stream${scenario.simultaneousHdStreams != 1 ? "s" : ""} (8 Mbps each)',
       if (scenario.simultaneousVideoCalls > 0)
         '${scenario.simultaneousVideoCalls} live video call${scenario.simultaneousVideoCalls != 1 ? "s" : ""} (6 Mbps down / 4 Mbps up)',
       if (scenario.remoteWorkers > 0)
@@ -159,17 +163,12 @@ class RecommendationEngine {
         '${counts[DeviceCategory.tv]} TV/streamer${(counts[DeviceCategory.tv]) != 1 ? "s" : ""} (typical ${DeviceCategory.tv.bandwidthProfile.typicalMbps} Mbps each)',
       if (scenario.largeDownloadHabit != LargeDownloadHabit.rarely)
         '${scenario.largeDownloadHabit.label} large downloads (+${_downloadHabitLoad(scenario.largeDownloadHabit)} Mbps)',
-      if (_concurrencyOverhead(scenario) > 0)
-        'Concurrency overhead: ${_concurrencyOverhead(scenario)} Mbps for ${scenario.simultaneous4kStreams + scenario.simultaneousHdStreams + scenario.simultaneousVideoCalls + scenario.remoteWorkers + scenario.onlineGamers} simultaneous active streams',
+      if (concurrencyOverhead > 0)
+        'Concurrency overhead: $concurrencyOverhead Mbps for ${scenario.simultaneous4kStreams + scenario.simultaneousHdStreams + scenario.simultaneousVideoCalls + scenario.remoteWorkers + scenario.onlineGamers} simultaneous active streams',
     ];
   }
 
   ConfidenceScore _confidenceFor(HouseholdScenario scenario) {
-    final detectedCounts = <DeviceCategory, int>{};
-    for (final device in scenario.devices) {
-      detectedCounts.update(device.category, (v) => v + 1, ifAbsent: () => 1);
-    }
-
     final highConfidenceDevices = scenario.devices.where((d) => d.confidence == ConfidenceScore.high).length;
     final totalDevices = scenario.devices.length;
     final ratio = totalDevices > 0 ? highConfidenceDevices / totalDevices : 0.0;

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -114,11 +114,13 @@ class RecommendationEngine {
     final totalCameras = detectedCameras > declaredCount ? detectedCameras : declaredCount;
     if (totalCameras == 0) return 0;
     final profile = DeviceCategory.camera.bandwidthProfile;
-    // Use the best detected camera confidence, or medium for declared-only cameras
-    final cameraConfidence = devices
-        .where((d) => d.category == DeviceCategory.camera)
-        .fold<ConfidenceScore>(ConfidenceScore.medium, (best, d) =>
-            d.confidence.index > best.index ? d.confidence : best);
+    final cameraDevices = devices.where((d) => d.category == DeviceCategory.camera);
+    // Use the best detected camera confidence; fall back to medium for declared-only cameras
+    final cameraConfidence = cameraDevices.isEmpty
+        ? ConfidenceScore.medium
+        : cameraDevices.fold<ConfidenceScore>(
+            cameraDevices.first.confidence, (best, d) =>
+                d.confidence.index > best.index ? d.confidence : best);
     return profile.mbpsForConfidence(cameraConfidence) * totalCameras;
   }
 

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -114,7 +114,12 @@ class RecommendationEngine {
     final totalCameras = detectedCameras > declaredCount ? detectedCameras : declaredCount;
     if (totalCameras == 0) return 0;
     final profile = DeviceCategory.camera.bandwidthProfile;
-    return profile.mbpsForConfidence(ConfidenceScore.medium) * totalCameras;
+    // Use the best detected camera confidence, or medium for declared-only cameras
+    final cameraConfidence = devices
+        .where((d) => d.category == DeviceCategory.camera)
+        .fold<ConfidenceScore>(ConfidenceScore.medium, (best, d) =>
+            d.confidence.index > best.index ? d.confidence : best);
+    return profile.mbpsForConfidence(cameraConfidence) * totalCameras;
   }
 
   int _withHeadroom(int value) => (value * 1.3).ceil();
@@ -148,6 +153,9 @@ class RecommendationEngine {
     Map<DeviceCategory, ConfidenceScore> maxConfidenceByCategory,
   ) {
     final concurrencyOverhead = _concurrencyOverhead(scenario);
+    final effectiveCameraCount = (counts[DeviceCategory.camera] ?? 0) > scenario.securityCameraCount
+        ? counts[DeviceCategory.camera]!
+        : scenario.securityCameraCount;
     return [
       '${scenario.simultaneous4kStreams} simultaneous 4K stream${scenario.simultaneous4kStreams != 1 ? "s" : ""} (25 Mbps each)',
       if (scenario.simultaneousHdStreams > 0)
@@ -158,8 +166,8 @@ class RecommendationEngine {
         '${scenario.remoteWorkers} remote worker${scenario.remoteWorkers != 1 ? "s" : ""} (10 Mbps each)',
       if (scenario.onlineGamers > 0)
         '${scenario.onlineGamers} online gamer${scenario.onlineGamers != 1 ? "s" : ""} (3 Mbps each)',
-      if (scenario.securityCameraCount > 0 || (counts[DeviceCategory.camera] ?? 0) > 0)
-        '${counts[DeviceCategory.camera] ?? scenario.securityCameraCount} security camera${(counts[DeviceCategory.camera] ?? scenario.securityCameraCount) != 1 ? "s" : ""} uploading footage',
+      if (effectiveCameraCount > 0)
+        '$effectiveCameraCount security camera${effectiveCameraCount != 1 ? "s" : ""} uploading footage',
       if (scenario.cloudBackupEnabled)
         'Cloud backup headroom included (20 Mbps)',
       '${scenario.devices.length} device${scenario.devices.length != 1 ? "s" : ""} on the network',

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -8,6 +8,15 @@ class RecommendationEngine {
       detectedCounts.update(device.category, (value) => value + 1, ifAbsent: () => 1);
     }
 
+    final maxConfidenceByCategory = <DeviceCategory, ConfidenceScore>{};
+    for (final device in scenario.devices) {
+      if (device.category == DeviceCategory.unknown) continue;
+      final existing = maxConfidenceByCategory[device.category];
+      if (existing == null || device.confidence.index > existing.index) {
+        maxConfidenceByCategory[device.category] = device.confidence;
+      }
+    }
+
     final downloadDemand =
         (scenario.simultaneous4kStreams * 25) +
         (scenario.simultaneousHdStreams * 8) +
@@ -15,7 +24,7 @@ class RecommendationEngine {
         (scenario.remoteWorkers * 10) +
         (scenario.onlineGamers * 3) +
         _downloadHabitLoad(scenario.largeDownloadHabit) +
-        _deviceBaselineDownloadWeighted(scenario.devices, detectedCounts) +
+        _deviceBaselineDownloadWeighted(maxConfidenceByCategory, detectedCounts) +
         _homeProfileDownload(scenario.homeProfile) +
         _concurrencyOverhead(scenario);
 
@@ -35,24 +44,15 @@ class RecommendationEngine {
       uploadMbps: normalizedUpload,
       planLabel: '${normalizedDownload}/${normalizedUpload}',
       summary: _summary(normalizedDownload, normalizedUpload),
-      reasons: _buildReasons(scenario, detectedCounts),
+      reasons: _buildReasons(scenario, detectedCounts, maxConfidenceByCategory),
       confidence: _confidenceFor(scenario),
     );
   }
 
   int _deviceBaselineDownloadWeighted(
-    List<DetectedDevice> devices,
+    Map<DeviceCategory, ConfidenceScore> maxConfidenceByCategory,
     Map<DeviceCategory, int> counts,
   ) {
-    final maxConfidenceByCategory = <DeviceCategory, ConfidenceScore>{};
-    for (final device in devices) {
-      if (device.category == DeviceCategory.unknown) continue;
-      final existing = maxConfidenceByCategory[device.category];
-      if (existing == null || device.confidence.index > existing.index) {
-        maxConfidenceByCategory[device.category] = device.confidence;
-      }
-    }
-
     int total = 0;
     for (final entry in counts.entries) {
       final category = entry.key;
@@ -111,7 +111,7 @@ class RecommendationEngine {
 
   int _cameraUploadLoad(List<DetectedDevice> devices, int declaredCount) {
     final detectedCameras = devices.where((d) => d.category == DeviceCategory.camera).length;
-    final totalCameras = detectedCameras > 0 ? detectedCameras : declaredCount;
+    final totalCameras = detectedCameras > declaredCount ? detectedCameras : declaredCount;
     if (totalCameras == 0) return 0;
     final profile = DeviceCategory.camera.bandwidthProfile;
     return profile.mbpsForConfidence(ConfidenceScore.medium) * totalCameras;
@@ -142,7 +142,11 @@ class RecommendationEngine {
     return 'Best for heavy simultaneous usage, many users, or creator-style upload needs.';
   }
 
-  List<String> _buildReasons(HouseholdScenario scenario, Map<DeviceCategory, int> counts) {
+  List<String> _buildReasons(
+    HouseholdScenario scenario,
+    Map<DeviceCategory, int> counts,
+    Map<DeviceCategory, ConfidenceScore> maxConfidenceByCategory,
+  ) {
     final concurrencyOverhead = _concurrencyOverhead(scenario);
     return [
       '${scenario.simultaneous4kStreams} simultaneous 4K stream${scenario.simultaneous4kStreams != 1 ? "s" : ""} (25 Mbps each)',
@@ -160,12 +164,23 @@ class RecommendationEngine {
         'Cloud backup headroom included (20 Mbps)',
       '${scenario.devices.length} device${scenario.devices.length != 1 ? "s" : ""} on the network',
       if ((counts[DeviceCategory.tv] ?? 0) > 0)
-        '${counts[DeviceCategory.tv]} TV/streamer${(counts[DeviceCategory.tv]) != 1 ? "s" : ""} (typical ${DeviceCategory.tv.bandwidthProfile.typicalMbps} Mbps each)',
+        '${counts[DeviceCategory.tv]} TV/streamer${(counts[DeviceCategory.tv]) != 1 ? "s" : ""} (${_confidenceLabel(maxConfidenceByCategory[DeviceCategory.tv])} ${DeviceCategory.tv.bandwidthProfile.mbpsForConfidence(maxConfidenceByCategory[DeviceCategory.tv] ?? ConfidenceScore.medium)} Mbps each)',
       if (scenario.largeDownloadHabit != LargeDownloadHabit.rarely)
         '${scenario.largeDownloadHabit.label} large downloads (+${_downloadHabitLoad(scenario.largeDownloadHabit)} Mbps)',
       if (concurrencyOverhead > 0)
         'Concurrency overhead: $concurrencyOverhead Mbps for ${scenario.simultaneous4kStreams + scenario.simultaneousHdStreams + scenario.simultaneousVideoCalls + scenario.remoteWorkers + scenario.onlineGamers} simultaneous active streams',
     ];
+  }
+
+  String _confidenceLabel(ConfidenceScore? confidence) {
+    switch (confidence ?? ConfidenceScore.medium) {
+      case ConfidenceScore.high:
+        return 'up to';
+      case ConfidenceScore.medium:
+        return '~';
+      case ConfidenceScore.low:
+        return 'at least';
+    }
   }
 
   ConfidenceScore _confidenceFor(HouseholdScenario scenario) {
@@ -177,7 +192,10 @@ class RecommendationEngine {
         scenario.simultaneousHdStreams > 0 ||
         scenario.simultaneousVideoCalls > 0 ||
         scenario.remoteWorkers > 0 ||
-        scenario.onlineGamers > 0;
+        scenario.onlineGamers > 0 ||
+        scenario.securityCameraCount > 0 ||
+        scenario.cloudBackupEnabled ||
+        scenario.largeDownloadHabit != LargeDownloadHabit.rarely;
 
     if (totalDevices >= 4 && ratio >= 0.6 && hasExplicitUsage) {
       return ConfidenceScore.high;

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -159,7 +159,8 @@ class RecommendationEngine {
         ? counts[DeviceCategory.camera]!
         : scenario.securityCameraCount;
     return [
-      '${scenario.simultaneous4kStreams} simultaneous 4K stream${scenario.simultaneous4kStreams != 1 ? "s" : ""} (25 Mbps each)',
+      if (scenario.simultaneous4kStreams > 0)
+        '${scenario.simultaneous4kStreams} simultaneous 4K stream${scenario.simultaneous4kStreams != 1 ? "s" : ""} (25 Mbps each)',
       if (scenario.simultaneousHdStreams > 0)
         '${scenario.simultaneousHdStreams} simultaneous HD stream${scenario.simultaneousHdStreams != 1 ? "s" : ""} (8 Mbps each)',
       if (scenario.simultaneousVideoCalls > 0)

--- a/packages/core/lib/src/recommendation_engine.dart
+++ b/packages/core/lib/src/recommendation_engine.dart
@@ -110,18 +110,20 @@ class RecommendationEngine {
   }
 
   int _cameraUploadLoad(List<DetectedDevice> devices, int declaredCount) {
-    final detectedCameras = devices.where((d) => d.category == DeviceCategory.camera).length;
+    final cameraDevices = devices.where((d) => d.category == DeviceCategory.camera).toList();
+    final detectedCameras = cameraDevices.length;
     final totalCameras = detectedCameras > declaredCount ? detectedCameras : declaredCount;
     if (totalCameras == 0) return 0;
     final profile = DeviceCategory.camera.bandwidthProfile;
-    final cameraDevices = devices.where((d) => d.category == DeviceCategory.camera);
-    // Use the best detected camera confidence; fall back to medium for declared-only cameras
-    final cameraConfidence = cameraDevices.isEmpty
+    // Best detected camera confidence for detected cameras; medium for declared-only
+    final detectedConfidence = cameraDevices.isEmpty
         ? ConfidenceScore.medium
         : cameraDevices.fold<ConfidenceScore>(
             cameraDevices.first.confidence, (best, d) =>
                 d.confidence.index > best.index ? d.confidence : best);
-    return profile.mbpsForConfidence(cameraConfidence) * totalCameras;
+    final declaredOnlyCount = declaredCount > detectedCameras ? declaredCount - detectedCameras : 0;
+    return (profile.mbpsForConfidence(detectedConfidence) * detectedCameras) +
+        (profile.mbpsForConfidence(ConfidenceScore.medium) * declaredOnlyCount);
   }
 
   int _withHeadroom(int value) => (value * 1.3).ceil();

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -337,6 +337,34 @@ void main() {
     expect(recommendation.uploadMbps, 20);
   });
 
+  test('camera upload blends detected and declared cameras with different confidence', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Camera 1',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 3,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    // 1 detected (high, typical=5 Mbps) + 2 declared-only (medium, 4 Mbps each) = 5 + 8 = 13
+    // Plus home small upload = 5, total = 18, headroom = 24 → 50
+    expect(recommendation.uploadMbps, 50);
+  });
+
   test('confidence is medium with cloud backup but no devices', () {
     final engine = RecommendationEngine();
     final scenario = HouseholdScenario(

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -191,7 +191,7 @@ void main() {
 
     final recommendation = engine.buildRecommendation(scenario);
 
-    expect(recommendation.reasons.any((r) => r.contains('25 Mbps each')), isTrue);
+    expect(recommendation.reasons.any((r) => r.contains('Mbps each')), isTrue);
     expect(recommendation.reasons.any((r) => r.contains('Concurrency overhead')), isTrue);
     expect(recommendation.reasons.any((r) => r.contains('Weekly large downloads')), isTrue);
   });
@@ -275,5 +275,130 @@ void main() {
     // Only home profile small (10 Mbps) + 30% headroom = 13 → round to 100
     // Unknown device should NOT contribute bandwidth
     expect(recommendation.downloadMbps, 100);
+  });
+
+  test('camera upload uses detected count when higher than declared', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Camera 1',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.medium,
+          connection: ConnectionType.wifi,
+        ),
+        DetectedDevice(
+          displayName: 'Camera 2',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.medium,
+          connection: ConnectionType.wifi,
+        ),
+        DetectedDevice(
+          displayName: 'Camera 3',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.medium,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 1,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    // 3 detected cameras with medium confidence: (2+5)/2=4 Mbps each * 3 = 12 Mbps upload
+    // Plus home profile small upload = 5, total = 17, headroom = 23 → normalize to 50
+    expect(recommendation.uploadMbps, 50);
+  });
+
+  test('camera upload uses declared count when no detected cameras', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 2,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    // 2 declared cameras * 4 Mbps each = 8, home profile upload = 5, total = 13, headroom = 17 → 20
+    expect(recommendation.uploadMbps, 20);
+  });
+
+  test('confidence is medium with cloud backup but no devices', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: true,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    expect(recommendation.confidence, ConfidenceScore.medium);
+  });
+
+  test('confidence is medium with daily download habit but no devices', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.daily,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    expect(recommendation.confidence, ConfidenceScore.medium);
+  });
+
+  test('TV reason shows confidence-weighted Mbps', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'TV',
+          category: DeviceCategory.tv,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 1,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    // High confidence TV should show "up to 25 Mbps each"
+    expect(recommendation.reasons.any((r) => r.contains('up to 25 Mbps each')), isTrue);
   });
 }

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -462,7 +462,7 @@ void main() {
     // Max confidence is high → typical Mbps for TV = 25, so 2 * 25 = 50
     // Home small = 10, total = 60, headroom = 78 → 100
     expect(recommendation.downloadMbps, 100);
-    // TV reason should show "up to" (high confidence label)
+    // TV reason should show "~" (high confidence label) with typical Mbps
     expect(recommendation.reasons.any((r) => r.contains('~ 25 Mbps each')), isTrue);
   });
 

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -401,4 +401,40 @@ void main() {
     // High confidence TV should show "up to 25 Mbps each"
     expect(recommendation.reasons.any((r) => r.contains('up to 25 Mbps each')), isTrue);
   });
+
+  test('mixed confidence within same category uses max confidence', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'TV 1',
+          category: DeviceCategory.tv,
+          confidence: ConfidenceScore.low,
+          connection: ConnectionType.wifi,
+        ),
+        DetectedDevice(
+          displayName: 'TV 2',
+          category: DeviceCategory.tv,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.ethernet,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    // Max confidence is high → typical Mbps for TV = 25, so 2 * 25 = 50
+    // Home small = 10, total = 60, headroom = 78 → 100
+    expect(recommendation.downloadMbps, 100);
+    // TV reason should show "up to" (high confidence label)
+    expect(recommendation.reasons.any((r) => r.contains('up to 25 Mbps each')), isTrue);
+  });
 }

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -441,15 +441,16 @@ void main() {
   test('low-confidence detected cameras use min Mbps, not medium', () {
     final engine = RecommendationEngine();
     final scenario = HouseholdScenario(
-      homeProfile: HomeProfile.small,
-      devices: const [
-        DetectedDevice(
+      homeProfile: HomeProfile.large,
+      devices: List.generate(
+        5,
+        (_) => const DetectedDevice(
           displayName: 'Camera',
           category: DeviceCategory.camera,
           confidence: ConfidenceScore.low,
           connection: ConnectionType.wifi,
         ),
-      ],
+      ),
       simultaneous4kStreams: 0,
       simultaneousHdStreams: 0,
       simultaneousVideoCalls: 0,
@@ -461,71 +462,10 @@ void main() {
     );
 
     final recommendation = engine.buildRecommendation(scenario);
-    // 1 low-confidence camera: minMbps=2, home upload=5, total=7, headroom=10 → 20
-    // If bug (medium instead of low): (2+5)/2=4, home=5, total=9, headroom=12 → 20
-    // Both happen to normalize to 20, so verify via reasons instead
-    // The key assertion: low confidence should NOT be treated as medium
-    // With proper logic, the effective camera upload is 2 Mbps (min)
-    // With the bug, it would be 4 Mbps (medium average)
-    // Let's verify the total upload to distinguish:
-    // With fix: 2 (camera min) + 5 (home small) = 7, *1.3 = 10 → 20
-    // With bug: 4 (camera medium) + 5 (home small) = 9, *1.3 = 12 → 20
-    // Both normalize to 20, so use a scenario where the difference matters
-    expect(recommendation.uploadMbps, 20);
-  });
-
-  test('low-confidence detected cameras produce lower upload than high-confidence', () {
-    final engine = RecommendationEngine();
-
-    final lowConfScenario = HouseholdScenario(
-      homeProfile: HomeProfile.small,
-      devices: const [
-        DetectedDevice(
-          displayName: 'Cam',
-          category: DeviceCategory.camera,
-          confidence: ConfidenceScore.low,
-          connection: ConnectionType.wifi,
-        ),
-      ],
-      simultaneous4kStreams: 0,
-      simultaneousHdStreams: 0,
-      simultaneousVideoCalls: 0,
-      remoteWorkers: 0,
-      onlineGamers: 0,
-      cloudBackupEnabled: false,
-      securityCameraCount: 0,
-      largeDownloadHabit: LargeDownloadHabit.rarely,
-    );
-
-    final highConfScenario = HouseholdScenario(
-      homeProfile: HomeProfile.small,
-      devices: const [
-        DetectedDevice(
-          displayName: 'Cam',
-          category: DeviceCategory.camera,
-          confidence: ConfidenceScore.high,
-          connection: ConnectionType.wifi,
-        ),
-      ],
-      simultaneous4kStreams: 0,
-      simultaneousHdStreams: 0,
-      simultaneousVideoCalls: 0,
-      remoteWorkers: 0,
-      onlineGamers: 0,
-      cloudBackupEnabled: false,
-      securityCameraCount: 0,
-      largeDownloadHabit: LargeDownloadHabit.rarely,
-    );
-
-    final lowRec = engine.buildRecommendation(lowConfScenario);
-    final highRec = engine.buildRecommendation(highConfScenario);
-    // High-confidence camera (5 Mbps typical) should produce higher or equal upload
-    // than low-confidence (2 Mbps min)
-    expect(highRec.uploadMbps, greaterThanOrEqualTo(lowRec.uploadMbps));
-    // Specifically, they should NOT be equal since 2 != 5
-    // low: 2 + 5 = 7 * 1.3 = 10 → 20
-    // high: 5 + 5 = 10 * 1.3 = 13 → 20
-    // Both normalize to 20 with 1 camera. Use more cameras to see difference.
+    // 5 low-confidence cameras * minMbps 2 = 10, home large upload = 20, total = 30
+    // headroom = 39 → 50
+    // If bug (medium=(2+5)/2=4): 5*4=20 + 20 = 40, headroom = 52 → 100
+    expect(recommendation.uploadMbps, 50);
   });
 
   test('multiple low-confidence cameras produce distinctly lower upload than high-confidence', () {

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -426,8 +426,8 @@ void main() {
     );
 
     final recommendation = engine.buildRecommendation(scenario);
-    // High confidence TV should show "up to 25 Mbps each"
-    expect(recommendation.reasons.any((r) => r.contains('up to 25 Mbps each')), isTrue);
+    // High confidence TV should show "~ 25 Mbps each"
+    expect(recommendation.reasons.any((r) => r.contains('~ 25 Mbps each')), isTrue);
   });
 
   test('mixed confidence within same category uses max confidence', () {
@@ -463,7 +463,7 @@ void main() {
     // Home small = 10, total = 60, headroom = 78 → 100
     expect(recommendation.downloadMbps, 100);
     // TV reason should show "up to" (high confidence label)
-    expect(recommendation.reasons.any((r) => r.contains('up to 25 Mbps each')), isTrue);
+    expect(recommendation.reasons.any((r) => r.contains('~ 25 Mbps each')), isTrue);
   });
 
   test('low-confidence detected cameras use min Mbps, not medium', () {

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -68,8 +68,157 @@ void main() {
 
     final recommendation = engine.buildRecommendation(scenario);
 
-    expect(recommendation.downloadMbps, 500);
-    expect(recommendation.uploadMbps, 100);
+    expect(recommendation.downloadMbps, 1000);
+    expect(recommendation.uploadMbps, 200);
     expect(recommendation.confidence, ConfidenceScore.high);
+  });
+
+  test('uses minMbps when device confidence is low', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Unknown TV',
+          category: DeviceCategory.tv,
+          confidence: ConfidenceScore.low,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+
+    // TV minMbps=5, home profile small=10, total=15, headroom=1.3x=20, normalize to 100
+    expect(recommendation.downloadMbps, 100);
+    // With 1 device (even low confidence), totalDevices >= 1 → medium
+    expect(recommendation.confidence, ConfidenceScore.medium);
+  });
+
+  test('returns low confidence when no devices and no usage data', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    expect(recommendation.confidence, ConfidenceScore.low);
+  });
+
+  test('DeviceBandwidthProfile mbpsForConfidence returns correct values', () {
+    const tvProfile = DeviceBandwidthProfile(minMbps: 5, typicalMbps: 25, maxMbps: 100);
+    expect(tvProfile.mbpsForConfidence(ConfidenceScore.high), 25);
+    expect(tvProfile.mbpsForConfidence(ConfidenceScore.medium), 15); // (5+25)/2 = 15
+    expect(tvProfile.mbpsForConfidence(ConfidenceScore.low), 5);
+  });
+
+  test('DeviceCategory.bandwidthProfile returns expected profiles', () {
+    expect(DeviceCategory.tv.bandwidthProfile.typicalMbps, 25);
+    expect(DeviceCategory.phone.bandwidthProfile.typicalMbps, 10);
+    expect(DeviceCategory.tablet.bandwidthProfile.typicalMbps, 10);
+    expect(DeviceCategory.laptop.bandwidthProfile.typicalMbps, 25);
+    expect(DeviceCategory.console.bandwidthProfile.typicalMbps, 25);
+    expect(DeviceCategory.camera.bandwidthProfile.typicalMbps, 5);
+    expect(DeviceCategory.smartHome.bandwidthProfile.typicalMbps, 2);
+    expect(DeviceCategory.nas.bandwidthProfile.typicalMbps, 10);
+  });
+
+  test('confidence is high when most devices are high-confidence with usage data', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.medium,
+      devices: List.generate(
+        4,
+        (index) => const DetectedDevice(
+          displayName: 'Device',
+          category: DeviceCategory.laptop,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+      ),
+      simultaneous4kStreams: 2,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 1,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    expect(recommendation.confidence, ConfidenceScore.high);
+  });
+
+  test('reasons include bandwidth explanations and concurrency overhead', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.medium,
+      devices: const [
+        DetectedDevice(
+          displayName: 'TV',
+          category: DeviceCategory.tv,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 3,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 2,
+      remoteWorkers: 1,
+      onlineGamers: 1,
+      cloudBackupEnabled: true,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.weekly,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+
+    expect(recommendation.reasons.any((r) => r.contains('25 Mbps each')), isTrue);
+    expect(recommendation.reasons.any((r) => r.contains('Concurrency overhead')), isTrue);
+    expect(recommendation.reasons.any((r) => r.contains('Weekly large downloads')), isTrue);
+  });
+
+  test('concurrency overhead is zero for light usage', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Phone',
+          category: DeviceCategory.phone,
+          confidence: ConfidenceScore.medium,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    expect(recommendation.reasons.any((r) => r.contains('Concurrency overhead')), isFalse);
   });
 }

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -437,4 +437,146 @@ void main() {
     // TV reason should show "up to" (high confidence label)
     expect(recommendation.reasons.any((r) => r.contains('up to 25 Mbps each')), isTrue);
   });
+
+  test('low-confidence detected cameras use min Mbps, not medium', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Camera',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.low,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    // 1 low-confidence camera: minMbps=2, home upload=5, total=7, headroom=10 → 20
+    // If bug (medium instead of low): (2+5)/2=4, home=5, total=9, headroom=12 → 20
+    // Both happen to normalize to 20, so verify via reasons instead
+    // The key assertion: low confidence should NOT be treated as medium
+    // With proper logic, the effective camera upload is 2 Mbps (min)
+    // With the bug, it would be 4 Mbps (medium average)
+    // Let's verify the total upload to distinguish:
+    // With fix: 2 (camera min) + 5 (home small) = 7, *1.3 = 10 → 20
+    // With bug: 4 (camera medium) + 5 (home small) = 9, *1.3 = 12 → 20
+    // Both normalize to 20, so use a scenario where the difference matters
+    expect(recommendation.uploadMbps, 20);
+  });
+
+  test('low-confidence detected cameras produce lower upload than high-confidence', () {
+    final engine = RecommendationEngine();
+
+    final lowConfScenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Cam',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.low,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final highConfScenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Cam',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final lowRec = engine.buildRecommendation(lowConfScenario);
+    final highRec = engine.buildRecommendation(highConfScenario);
+    // High-confidence camera (5 Mbps typical) should produce higher or equal upload
+    // than low-confidence (2 Mbps min)
+    expect(highRec.uploadMbps, greaterThanOrEqualTo(lowRec.uploadMbps));
+    // Specifically, they should NOT be equal since 2 != 5
+    // low: 2 + 5 = 7 * 1.3 = 10 → 20
+    // high: 5 + 5 = 10 * 1.3 = 13 → 20
+    // Both normalize to 20 with 1 camera. Use more cameras to see difference.
+  });
+
+  test('multiple low-confidence cameras produce distinctly lower upload than high-confidence', () {
+    final engine = RecommendationEngine();
+
+    final lowConfScenario = HouseholdScenario(
+      homeProfile: HomeProfile.large,
+      devices: List.generate(
+        5,
+        (_) => const DetectedDevice(
+          displayName: 'Cam',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.low,
+          connection: ConnectionType.wifi,
+        ),
+      ),
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final highConfScenario = HouseholdScenario(
+      homeProfile: HomeProfile.large,
+      devices: List.generate(
+        5,
+        (_) => const DetectedDevice(
+          displayName: 'Cam',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+      ),
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final lowRec = engine.buildRecommendation(lowConfScenario);
+    final highRec = engine.buildRecommendation(highConfScenario);
+    // low: 5 cameras * 2 Mbps + 20 (large profile) = 30 * 1.3 = 39 → 50
+    // high: 5 cameras * 5 Mbps + 20 (large profile) = 45 * 1.3 = 59 → 100
+    expect(lowRec.uploadMbps, lessThan(highRec.uploadMbps));
+  });
 }

--- a/packages/core/test/recommendation_engine_test.dart
+++ b/packages/core/test/recommendation_engine_test.dart
@@ -221,4 +221,59 @@ void main() {
     final recommendation = engine.buildRecommendation(scenario);
     expect(recommendation.reasons.any((r) => r.contains('Concurrency overhead')), isFalse);
   });
+
+  test('HD streams appear in reasons when present', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'TV',
+          category: DeviceCategory.tv,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 2,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    expect(recommendation.reasons.any((r) => r.contains('HD stream')), isTrue);
+    expect(recommendation.reasons.any((r) => r.contains('8 Mbps each')), isTrue);
+  });
+
+  test('unknown devices are excluded from baseline', () {
+    final engine = RecommendationEngine();
+    final scenario = HouseholdScenario(
+      homeProfile: HomeProfile.small,
+      devices: const [
+        DetectedDevice(
+          displayName: 'Mystery Device',
+          category: DeviceCategory.unknown,
+          confidence: ConfidenceScore.low,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      simultaneous4kStreams: 0,
+      simultaneousHdStreams: 0,
+      simultaneousVideoCalls: 0,
+      remoteWorkers: 0,
+      onlineGamers: 0,
+      cloudBackupEnabled: false,
+      securityCameraCount: 0,
+      largeDownloadHabit: LargeDownloadHabit.rarely,
+    );
+
+    final recommendation = engine.buildRecommendation(scenario);
+    // Only home profile small (10 Mbps) + 30% headroom = 13 → round to 100
+    // Unknown device should NOT contribute bandwidth
+    expect(recommendation.downloadMbps, 100);
+  });
 }


### PR DESCRIPTION
## Summary

Adds configurable device bandwidth profiles per category, improves the recommendation engine with confidence-weighted bandwidth usage, better concurrency modeling, and clearer plain-English explanations.

## Changes

- **Device bandwidth profiles**: Added `DeviceBandwidthProfile` class with `minMbps`/`typicalMbps`/`maxMbps` and `mbpsForConfidence()` method on each `DeviceCategory`
- **Confidence-weighted baseline**: Device bandwidth contribution now scales with detection confidence (high → typical, medium → average of min/typical, low → min)
- **Concurrency overhead**: Added `_concurrencyOverhead()` to model the cost of many simultaneous streams (10/20/30 Mbps for 3-5/6-8/9+ active streams)
- **Improved camera upload**: Uses camera bandwidth profile instead of flat 3 Mbps per camera
- **Better explanations**: Reasons now include Mbps per item, proper pluralization, concurrency overhead line, and download habit callouts
- **Improved confidence scoring**: High confidence now requires ≥4 devices with ≥60% high-confidence AND explicit usage data; medium requires any devices or usage; low only when no devices and no usage data

Closes #2