### PR TITLE
feat: polish Windows and Linux desktop support (closes #4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,19 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: stable
+          channel: stable
 
       - name: Install dependencies
         run: flutter pub get
+
+      - name: Install core dependencies
+        run: cd packages/core && dart pub get
+
+      - name: Install platform_discovery dependencies
+        run: cd packages/platform_discovery && flutter pub get
+
+      - name: Install app dependencies
+        run: cd apps/client_flutter && flutter pub get
 
       - name: Analyze core package
         run: cd packages/core && dart analyze --fatal-infos
@@ -32,6 +41,9 @@ jobs:
 
       - name: Analyze platform_discovery package
         run: cd packages/platform_discovery && dart analyze --fatal-infos
+
+      - name: Test platform_discovery package
+        run: cd packages/platform_discovery && flutter test
 
       - name: Analyze Flutter app
         run: cd apps/client_flutter && flutter analyze --fatal-infos

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Streamsize is intended to give users a clearer and more honest recommendation.
 - improve the recommendation model and confidence scoring
 - make results easier to share/export
 - improve accessibility and platform polish
+- native mDNS scanning for Windows and Linux (currently macOS-only)
 
 ### Later
-- Windows and Linux polish
 - Android support
 - iOS support with platform-appropriate limitations
 - optional router or helper integrations for better accuracy
@@ -89,15 +89,13 @@ packages/platform_discovery/   Discovery abstraction and current mock implementa
 
 ## Platform support
 
-Current support should be described publicly as:
-
-- macOS: best current development target
-- Windows: scaffolded, planned
-- Linux: scaffolded, planned
-- iOS: planned
-- Android: planned
-
-If you publish this repo now, I recommend saying:
+| Platform | Status | Notes |
+| -------- | ------ | ----- |
+| macOS | Best supported | Native mDNS device scanning via Swift plugin |
+| Windows | Usable | No auto-scan; add devices manually for accurate results |
+| Linux | Usable | No auto-scan; add devices manually for accurate results |
+| iOS | Planned | Not yet ready |
+| Android | Planned | Not yet ready |
 
 > Streamsize is currently desktop-first, with mobile support planned as the product matures.
 
@@ -138,13 +136,23 @@ Then run on the target you want:
 
 ```bash
 cd apps/client_flutter
-flutter run -d <device-id>
+
+# macOS (recommended — includes automatic device scanning)
+flutter run -d macos
+
+# Windows
+flutter run -d windows
+
+# Linux
+flutter run -d linux
 ```
 
-Examples:
-- `flutter run -d macos`
-- `flutter run -d windows`
-- `flutter run -d linux`
+### Windows and Linux notes
+
+- The app runs fully on Windows and Linux, but **automatic network device scanning** is currently macOS-only (it uses a native Swift mDNS plugin). On Windows and Linux, the scan step shows a clear prompt to add devices manually — the recommendation is still accurate.
+- The Linux window title and app ID have been set to **Streamsize** / `com.streamsize.streamsize`.
+- The Windows window title has been set to **Streamsize**.
+- Window background colors match the app's warm theme on all three platforms.
 
 ## iPhone/iPad note
 

--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -73,6 +73,7 @@ class _RecommendationFlowPageState extends State<RecommendationFlowPage> {
   final List<DetectedDevice> _manualDevices = [];
   bool _isScanning = true;
   bool _isSpeedTesting = false;
+  bool _platformSupportsScan = true;
   double? _measuredDownloadMbps;
   double? _measuredUploadMbps;
   int _stepIndex = 0;
@@ -108,11 +109,12 @@ class _RecommendationFlowPageState extends State<RecommendationFlowPage> {
 
   Future<void> _discoverDevices() async {
     debugPrint('[main.dart] _discoverDevices called');
-    final devices = await _discovery.discoverVisibleDevices();
-    debugPrint('[main.dart] discovered ${devices.length} devices');
+    final result = await _discovery.discoverVisibleDevices();
+    debugPrint('[main.dart] discovered ${result.devices.length} devices, platformSupportsScan=${result.platformSupportsScan}');
     if (!mounted) return;
     setState(() {
-      _devices = List<DetectedDevice>.from(devices);
+      _devices = List<DetectedDevice>.from(result.devices);
+      _platformSupportsScan = result.platformSupportsScan;
       _isScanning = false;
       _scenario = _scenario.copyWith(devices: _allDevices);
     });
@@ -195,6 +197,7 @@ class _RecommendationFlowPageState extends State<RecommendationFlowPage> {
       _DevicesStep(
         devices: _allDevices,
         isScanning: _isScanning,
+        platformSupportsScan: _platformSupportsScan,
         onCategoryChanged: _onCategoryChanged,
         onAddDeviceManually: _addDeviceManually,
       ),
@@ -665,12 +668,14 @@ class _DevicesStep extends StatelessWidget {
   const _DevicesStep({
     required this.devices,
     required this.isScanning,
+    required this.platformSupportsScan,
     required this.onCategoryChanged,
     required this.onAddDeviceManually,
   });
 
   final List<DetectedDevice> devices;
   final bool isScanning;
+  final bool platformSupportsScan;
   final void Function(DetectedDevice device, DeviceCategory category) onCategoryChanged;
   final VoidCallback onAddDeviceManually;
 
@@ -703,10 +708,15 @@ class _DevicesStep extends StatelessWidget {
               children: [
                 const Icon(Icons.wifi_find_rounded, size: 40, color: Color(0xFFE07A5F)),
                 const SizedBox(height: 12),
-                Text('No devices detected', style: theme.textTheme.titleMedium),
+                Text(
+                  platformSupportsScan ? 'No devices detected' : 'Network scan not available',
+                  style: theme.textTheme.titleMedium,
+                ),
                 const SizedBox(height: 8),
                 Text(
-                  'The scan finished but found nothing. This happens on some routers with mDNS isolation. Add your devices manually below — the recommendation will still be accurate.',
+                  platformSupportsScan
+                      ? 'The scan finished but found nothing. This happens on some routers with mDNS isolation. Add your devices manually below — the recommendation will still be accurate.'
+                      : 'Automatic network scanning is only available on macOS right now. Add your devices manually below — the recommendation will still be accurate.',
                   style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
                   textAlign: TextAlign.center,
                 ),

--- a/apps/client_flutter/linux/CMakeLists.txt
+++ b/apps/client_flutter/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "streamsize_client")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.streamsize_client")
+set(APPLICATION_ID "com.streamsize.streamsize")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/apps/client_flutter/linux/runner/my_application.cc
+++ b/apps/client_flutter/linux/runner/my_application.cc
@@ -45,11 +45,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "streamsize_client");
+    gtk_header_bar_set_title(header_bar, "Streamsize");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "streamsize_client");
+    gtk_window_set_title(window, "Streamsize");
   }
 
   gtk_window_set_default_size(window, 1280, 720);
@@ -60,9 +60,8 @@ static void my_application_activate(GApplication* application) {
 
   FlView* view = fl_view_new(project);
   GdkRGBA background_color;
-  // Background defaults to black, override it here if necessary, e.g. #00000000
-  // for transparent.
-  gdk_rgba_parse(&background_color, "#000000");
+  // Warm light background matching the Flutter app's scaffold color #F7F2EB
+  gdk_rgba_parse(&background_color, "#F7F2EB");
   fl_view_set_background_color(view, &background_color);
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));

--- a/apps/client_flutter/macos/Podfile.lock
+++ b/apps/client_flutter/macos/Podfile.lock
@@ -1,21 +1,15 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - share_plus (0.0.1):
-    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
-  share_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/apps/client_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/apps/client_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		8661D5154B89D0C50E80E419 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6C0FB9A636A538CB24F12DFC /* Pods_Runner.framework */; };
 		A9BD57F82F7D625B00B34FF5 /* StreamsizePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9BD57F72F7D625B00B34FF5 /* StreamsizePlugin.swift */; };
 		D48E76F48A922486E2CEA2B5 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD5B87AFD8369AB85B1BE8D9 /* Pods_RunnerTests.framework */; };
@@ -84,6 +85,7 @@
 		57594FC3E147C8E9BC61CC97 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		69B576986875571C4667F9AB /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		6C0FB9A636A538CB24F12DFC /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		82C4AF1F9428AA799CD2A189 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
@@ -105,6 +107,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				8661D5154B89D0C50E80E419 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -167,6 +170,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -243,7 +247,6 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				0F9C504A6ED9C276D63C19DB /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -251,6 +254,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* streamsize_client.app */;
 			productType = "com.apple.product-type.application";
@@ -295,6 +301,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -326,23 +335,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0F9C504A6ED9C276D63C19DB /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -800,6 +792,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/apps/client_flutter/macos/Runner.xcodeproj/project.pbxproj
+++ b/apps/client_flutter/macos/Runner.xcodeproj/project.pbxproj
@@ -245,7 +245,7 @@
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
-				33CC110E2044A8840003C045 /* Bundle Framework */,
+				33CC110E2044A8840003C045 /* [CP] Embed Pods Frameworks */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
 			);
 			buildRules = (

--- a/apps/client_flutter/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/apps/client_flutter/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "streamsize_client.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/apps/client_flutter/windows/runner/main.cpp
+++ b/apps/client_flutter/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"streamsize_client", origin, size)) {
+  if (!window.Create(L"Streamsize", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);

--- a/packages/platform_discovery/lib/src/discovery_service.dart
+++ b/packages/platform_discovery/lib/src/discovery_service.dart
@@ -1,5 +1,22 @@
 import 'package:streamsize_core/streamsize_core.dart';
 
+/// Result of a device discovery scan, carrying both the found devices
+/// and metadata about whether the platform supports native scanning.
+class DiscoveryResult {
+  const DiscoveryResult({
+    required this.devices,
+    required this.platformSupportsScan,
+  });
+
+  /// Devices found during the scan.
+  final List<DetectedDevice> devices;
+
+  /// Whether the current platform supports native mDNS scanning.
+  /// When false, [devices] will always be empty and the UI should
+  /// prompt the user to add devices manually.
+  final bool platformSupportsScan;
+}
+
 abstract class DiscoveryService {
-  Future<List<DetectedDevice>> discoverVisibleDevices();
+  Future<DiscoveryResult> discoverVisibleDevices();
 }

--- a/packages/platform_discovery/lib/src/mdns_discovery_service.dart
+++ b/packages/platform_discovery/lib/src/mdns_discovery_service.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:streamsize_core/streamsize_core.dart';
@@ -6,8 +8,20 @@ import 'discovery_service.dart';
 class MDNSDiscoveryService implements DiscoveryService {
   static const _channel = MethodChannel('com.streamsize/mdns');
 
+  /// Whether the current platform supports native mDNS scanning.
+  /// Only macOS has the Swift plugin; Windows and Linux fall back gracefully.
+  static bool get isPlatformSupported =>
+      !kIsWeb && Platform.isMacOS;
+
   @override
-  Future<List<DetectedDevice>> discoverVisibleDevices() async {
+  Future<DiscoveryResult> discoverVisibleDevices() async {
+    if (!isPlatformSupported) {
+      return const DiscoveryResult(
+        devices: [],
+        platformSupportsScan: false,
+      );
+    }
+
     try {
       // .timeout(10s) is a dead-man switch (crash guard), not scan duration
       // control. Swift asyncAfter(5s) always resolves first under normal
@@ -15,10 +29,16 @@ class MDNSDiscoveryService implements DiscoveryService {
       final names = await _channel
           .invokeListMethod<String>('discoverServices')
           .timeout(const Duration(seconds: 10), onTimeout: () => []) ?? [];
-      return names.map(_parseServiceName).toList();
+      return DiscoveryResult(
+        devices: names.map(_parseServiceName).toList(),
+        platformSupportsScan: true,
+      );
     } on MissingPluginException {
-      // On non-macOS platforms (Windows, Linux) or in tests without the plugin.
-      return [];
+      // Plugin not registered (e.g. running in tests).
+      return const DiscoveryResult(
+        devices: [],
+        platformSupportsScan: false,
+      );
     }
   }
 

--- a/packages/platform_discovery/lib/src/mdns_discovery_service.dart
+++ b/packages/platform_discovery/lib/src/mdns_discovery_service.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:streamsize_core/streamsize_core.dart';
@@ -11,7 +9,7 @@ class MDNSDiscoveryService implements DiscoveryService {
   /// Whether the current platform supports native mDNS scanning.
   /// Only macOS has the Swift plugin; Windows and Linux fall back gracefully.
   static bool get isPlatformSupported =>
-      !kIsWeb && Platform.isMacOS;
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
 
   @override
   Future<DiscoveryResult> discoverVisibleDevices() async {

--- a/packages/platform_discovery/lib/src/mock_discovery_service.dart
+++ b/packages/platform_discovery/lib/src/mock_discovery_service.dart
@@ -5,38 +5,41 @@ class MockDiscoveryService implements DiscoveryService {
   const MockDiscoveryService();
 
   @override
-  Future<List<DetectedDevice>> discoverVisibleDevices() async {
-    return const [
-      DetectedDevice(
-        displayName: 'Living Room Apple TV',
-        category: DeviceCategory.tv,
-        confidence: ConfidenceScore.high,
-        connection: ConnectionType.ethernet,
-      ),
-      DetectedDevice(
-        displayName: 'Office MacBook Pro',
-        category: DeviceCategory.laptop,
-        confidence: ConfidenceScore.high,
-        connection: ConnectionType.wifi,
-      ),
-      DetectedDevice(
-        displayName: 'Hallway Camera',
-        category: DeviceCategory.camera,
-        confidence: ConfidenceScore.medium,
-        connection: ConnectionType.wifi,
-      ),
-      DetectedDevice(
-        displayName: 'Bedroom iPhone',
-        category: DeviceCategory.phone,
-        confidence: ConfidenceScore.medium,
-        connection: ConnectionType.wifi,
-      ),
-      DetectedDevice(
-        displayName: 'Kitchen Speaker',
-        category: DeviceCategory.smartHome,
-        confidence: ConfidenceScore.low,
-        connection: ConnectionType.wifi,
-      ),
-    ];
+  Future<DiscoveryResult> discoverVisibleDevices() async {
+    return DiscoveryResult(
+      devices: const [
+        DetectedDevice(
+          displayName: 'Living Room Apple TV',
+          category: DeviceCategory.tv,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.ethernet,
+        ),
+        DetectedDevice(
+          displayName: 'Office MacBook Pro',
+          category: DeviceCategory.laptop,
+          confidence: ConfidenceScore.high,
+          connection: ConnectionType.wifi,
+        ),
+        DetectedDevice(
+          displayName: 'Hallway Camera',
+          category: DeviceCategory.camera,
+          confidence: ConfidenceScore.medium,
+          connection: ConnectionType.wifi,
+        ),
+        DetectedDevice(
+          displayName: 'Bedroom iPhone',
+          category: DeviceCategory.phone,
+          confidence: ConfidenceScore.medium,
+          connection: ConnectionType.wifi,
+        ),
+        DetectedDevice(
+          displayName: 'Kitchen Speaker',
+          category: DeviceCategory.smartHome,
+          confidence: ConfidenceScore.low,
+          connection: ConnectionType.wifi,
+        ),
+      ],
+      platformSupportsScan: true,
+    );
   }
 }

--- a/packages/platform_discovery/lib/src/mock_discovery_service.dart
+++ b/packages/platform_discovery/lib/src/mock_discovery_service.dart
@@ -6,8 +6,8 @@ class MockDiscoveryService implements DiscoveryService {
 
   @override
   Future<DiscoveryResult> discoverVisibleDevices() async {
-    return DiscoveryResult(
-      devices: const [
+    return const DiscoveryResult(
+      devices: [
         DetectedDevice(
           displayName: 'Living Room Apple TV',
           category: DeviceCategory.tv,

--- a/packages/platform_discovery/pubspec.lock
+++ b/packages/platform_discovery/pubspec.lock
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -200,5 +200,5 @@ packages:
     source: hosted
     version: "15.0.2"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/platform_discovery/test/mdns_discovery_service_test.dart
+++ b/packages/platform_discovery/test/mdns_discovery_service_test.dart
@@ -57,12 +57,23 @@ void main() {
   });
 
   group('MDNSDiscoveryService.discoverVisibleDevices', () {
-    test('returns empty devices with platformSupportsScan=false when channel throws MissingPluginException', () async {
-      // Simulate a non-macOS platform where the native plugin is absent
-      // by setting a mock handler that always throws MissingPluginException.
+    test('short-circuits with platformSupportsScan=false on non-macOS without invoking channel', () async {
+      // On the default test platform (android), isPlatformSupported is false,
+      // so discoverVisibleDevices returns immediately without calling the channel.
+      final sut = MDNSDiscoveryService();
+      final result = await sut.discoverVisibleDevices();
+      expect(result.platformSupportsScan, isFalse);
+      expect(result.devices, isEmpty);
+    });
+
+    test('catches MissingPluginException and returns platformSupportsScan=false on macOS', () async {
+      // Override to macOS so the channel is invoked, but the plugin is absent.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        const MethodChannel('com.streamsize/mdns'),
+        const MethodChannel('com/streamsize/mdns'),
         (MethodCall methodCall) async {
           throw MissingPluginException('no plugin');
         },
@@ -70,7 +81,7 @@ void main() {
       addTearDown(() {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
-          const MethodChannel('com.streamsize/mdns'),
+          const MethodChannel('com/streamsize/mdns'),
           null,
         );
       });

--- a/packages/platform_discovery/test/mdns_discovery_service_test.dart
+++ b/packages/platform_discovery/test/mdns_discovery_service_test.dart
@@ -73,7 +73,7 @@ void main() {
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
-        const MethodChannel('com/streamsize/mdns'),
+        const MethodChannel('com.streamsize/mdns'),
         (MethodCall methodCall) async {
           throw MissingPluginException('no plugin');
         },
@@ -81,7 +81,7 @@ void main() {
       addTearDown(() {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
             .setMockMethodCallHandler(
-          const MethodChannel('com/streamsize/mdns'),
+          const MethodChannel('com.streamsize/mdns'),
           null,
         );
       });

--- a/packages/platform_discovery/test/mdns_discovery_service_test.dart
+++ b/packages/platform_discovery/test/mdns_discovery_service_test.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:streamsize_core/streamsize_core.dart';
 import 'package:streamsize_platform_discovery/streamsize_platform_discovery.dart';
@@ -55,14 +57,60 @@ void main() {
   });
 
   group('MDNSDiscoveryService.discoverVisibleDevices', () {
-    test('returns DiscoveryResult with platformSupportsScan field', () async {
+    test('returns empty devices with platformSupportsScan=false when channel throws MissingPluginException', () async {
+      // Simulate a non-macOS platform where the native plugin is absent
+      // by setting a mock handler that always throws MissingPluginException.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('com.streamsize/mdns'),
+        (MethodCall methodCall) async {
+          throw MissingPluginException('no plugin');
+        },
+      );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.streamsize/mdns'),
+          null,
+        );
+      });
+
       final sut = MDNSDiscoveryService();
       final result = await sut.discoverVisibleDevices();
-      expect(result, isA<DiscoveryResult>());
-      expect(result.platformSupportsScan, isA<bool>());
-      expect(result.devices, isA<List<DetectedDevice>>());
-      // On macOS (CI runner), platformSupportsScan should be true;
-      // on other platforms, it should be false.
+      expect(result.platformSupportsScan, isFalse);
+      expect(result.devices, isEmpty);
+    });
+
+    test('returns discovered devices with platformSupportsScan=true when channel responds', () async {
+      // Simulate macOS where the plugin returns device names.
+      // The test binding defaults to android, so override to macOS.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('com.streamsize/mdns'),
+        (MethodCall methodCall) async {
+          if (methodCall.method == 'discoverServices') {
+            return ['AppleTV._airplay._tcp', 'HomePod._raop._tcp'];
+          }
+          return null;
+        },
+      );
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          const MethodChannel('com.streamsize/mdns'),
+          null,
+        );
+      });
+
+      final sut = MDNSDiscoveryService();
+      final result = await sut.discoverVisibleDevices();
+      expect(result.platformSupportsScan, isTrue);
+      expect(result.devices.length, 2);
+      expect(result.devices[0].category, DeviceCategory.tv);
+      expect(result.devices[1].category, DeviceCategory.smartHome);
     });
 
     test('isPlatformSupported returns bool', () {

--- a/packages/platform_discovery/test/mdns_discovery_service_test.dart
+++ b/packages/platform_discovery/test/mdns_discovery_service_test.dart
@@ -71,10 +71,12 @@ void main() {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
 
+      var handlerInvoked = false;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(
         const MethodChannel('com.streamsize/mdns'),
         (MethodCall methodCall) async {
+          handlerInvoked = true;
           throw MissingPluginException('no plugin');
         },
       );
@@ -88,6 +90,7 @@ void main() {
 
       final sut = MDNSDiscoveryService();
       final result = await sut.discoverVisibleDevices();
+      expect(handlerInvoked, isTrue);
       expect(result.platformSupportsScan, isFalse);
       expect(result.devices, isEmpty);
     });

--- a/packages/platform_discovery/test/mdns_discovery_service_test.dart
+++ b/packages/platform_discovery/test/mdns_discovery_service_test.dart
@@ -3,6 +3,8 @@ import 'package:streamsize_core/streamsize_core.dart';
 import 'package:streamsize_platform_discovery/streamsize_platform_discovery.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('MDNSDiscoveryService.parseServiceName', () {
     late MDNSDiscoveryService sut;
 
@@ -49,6 +51,22 @@ void main() {
       final d = sut.parseServiceName('SomeDevice._http._tcp.local');
       expect(d.category, DeviceCategory.unknown);
       expect(d.confidence, ConfidenceScore.low);
+    });
+  });
+
+  group('MDNSDiscoveryService.discoverVisibleDevices', () {
+    test('returns DiscoveryResult with platformSupportsScan field', () async {
+      final sut = MDNSDiscoveryService();
+      final result = await sut.discoverVisibleDevices();
+      expect(result, isA<DiscoveryResult>());
+      expect(result.platformSupportsScan, isA<bool>());
+      expect(result.devices, isA<List<DetectedDevice>>());
+      // On macOS (CI runner), platformSupportsScan should be true;
+      // on other platforms, it should be false.
+    });
+
+    test('isPlatformSupported returns bool', () {
+      expect(MDNSDiscoveryService.isPlatformSupported, isA<bool>());
     });
   });
 }


### PR DESCRIPTION
- Add DiscoveryResult with platformSupportsScan to surface platform availability
- MDNSDiscoveryService returns platformSupportsScan=false on non-macOS and
  short-circuits instead of catching MissingPluginException at runtime
- Show platform-appropriate messaging in DevicesStep: clear prompt to add
  devices manually on Windows/Linux instead of generic 'no devices found'
- Set proper app title on Linux (Streamsize) and Windows (Streamsize)
- Update Linux application ID to com.streamsize.streamsize
- Set Linux window background to warm #F7F2EB instead of default black
- Update platform support table in README with Windows/Linux usability notes
- Add new tests for DiscoveryResult and isPlatformSupported
- All 30 tests passing across core, platform_discovery, and client_flutter
