### PR TITLE
feat: add accessibility and onboarding polish for v0.1 (closes #5)

### DIFF
--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -466,28 +466,30 @@ class _IntroPanel extends StatelessWidget {
               child: Semantics(
                 label: 'Step ${index + 1}: ${_stepTitles[index]}${index < stepIndex ? ' (completed)' : index == stepIndex ? ' (current)' : ''}',
                 container: true,
-                child: Row(
-                  children: [
-                    AnimatedContainer(
-                      duration: const Duration(milliseconds: 220),
-                      width: 34,
-                      height: 34,
-                      decoration: BoxDecoration(
-                        color: index <= stepIndex ? const Color(0xFFE07A5F) : Colors.white,
-                        borderRadius: BorderRadius.circular(999),
-                      ),
-                      alignment: Alignment.center,
-                      child: Text(
-                        '${index + 1}',
-                        style: TextStyle(
-                          color: index <= stepIndex ? Colors.white : const Color(0xFF5C5468),
-                          fontWeight: FontWeight.w700,
+                child: ExcludeSemantics(
+                  child: Row(
+                    children: [
+                      AnimatedContainer(
+                        duration: const Duration(milliseconds: 220),
+                        width: 34,
+                        height: 34,
+                        decoration: BoxDecoration(
+                          color: index <= stepIndex ? const Color(0xFFE07A5F) : Colors.white,
+                          borderRadius: BorderRadius.circular(999),
+                        ),
+                        alignment: Alignment.center,
+                        child: Text(
+                          '${index + 1}',
+                          style: TextStyle(
+                            color: index <= stepIndex ? Colors.white : const Color(0xFF5C5468),
+                            fontWeight: FontWeight.w700,
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    Text(_stepTitles[index], style: theme.textTheme.titleMedium),
-                  ],
+                      const SizedBox(width: 12),
+                      Text(_stepTitles[index], style: theme.textTheme.titleMedium),
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -571,35 +573,41 @@ class _FlowCard extends StatelessWidget {
           Row(
             children: [
               if (onBack != null)
-                Tooltip(
-                  message: 'Back to step $stepIndex of 4',
-                  child: OutlinedButton(
-                    onPressed: onBack,
-                    style: OutlinedButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+                Builder(builder: (context) {
+                  final backLabel = 'Back to step $stepIndex of 4';
+                  return Tooltip(
+                    message: backLabel,
+                    child: OutlinedButton(
+                      onPressed: onBack,
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                      ),
+                      child: Semantics(
+                        label: backLabel,
+                        child: const Text('Back'),
+                      ),
+                    ),
+                  );
+                }),
+              const Spacer(),
+              Builder(builder: (context) {
+                final nextLabel = isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4';
+                return Tooltip(
+                  message: nextLabel,
+                  child: FilledButton(
+                    onPressed: onNext,
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 18),
                       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
                     ),
                     child: Semantics(
-                      label: 'Back to step $stepIndex of 4',
-                      child: const Text('Back'),
+                      label: nextLabel,
+                      child: Text(isLast ? 'Start over' : 'Continue'),
                     ),
                   ),
-                ),
-              const Spacer(),
-              Tooltip(
-                message: isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4',
-                child: FilledButton(
-                  onPressed: onNext,
-                  style: FilledButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 18),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-                  ),
-                  child: Semantics(
-                    label: isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4',
-                    child: Text(isLast ? 'Start over' : 'Continue'),
-                  ),
-                ),
-              ),
+                );
+              }),
             ],
           ),
         ],
@@ -827,17 +835,20 @@ class _DevicesStep extends StatelessWidget {
           ),
         ],
         // "Add manually" text link — macOS-native feel; FABs are mobile-native.
-        Tooltip(
-          message: 'Add a device that the scan may have missed',
-          child: TextButton.icon(
-            onPressed: onAddDeviceManually,
-            icon: const Icon(Icons.add_circle_outline_rounded, size: 18),
-            label: Semantics(
-              label: 'Add a device that the scan may have missed',
-              child: const Text('Add a device manually'),
+        Builder(builder: (context) {
+          const addLabel = 'Add a device that the scan may have missed';
+          return Tooltip(
+            message: addLabel,
+            child: TextButton.icon(
+              onPressed: onAddDeviceManually,
+              icon: const Icon(Icons.add_circle_outline_rounded, size: 18),
+              label: Semantics(
+                label: addLabel,
+                child: const Text('Add a device manually'),
+              ),
             ),
-          ),
-        ),
+          );
+        }),
       ],
     );
   }
@@ -1340,7 +1351,9 @@ class _ProgressHeader extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Step ${stepIndex + 1} of 4', style: Theme.of(context).textTheme.labelLarge),
+          ExcludeSemantics(
+            child: Text('Step ${stepIndex + 1} of 4', style: Theme.of(context).textTheme.labelLarge),
+          ),
           const SizedBox(height: 12),
           Row(
             children: List.generate(

--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -648,23 +648,28 @@ class _WelcomeStep extends StatelessWidget {
           const SizedBox(height: 20),
           Semantics(
             label: 'Scanning your network for devices. Please wait.',
-            child: Row(
-              children: [
-                const SizedBox(
-                  width: 16,
-                  height: 16,
-                  child: CircularProgressIndicator(strokeWidth: 2),
-                ),
-                const SizedBox(width: 10),
-                Text('Scanning your network...', style: theme.textTheme.bodyMedium),
-              ],
+            container: true,
+            child: ExcludeSemantics(
+              child: Row(
+                children: [
+                  const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 10),
+                  Text('Scanning your network...', style: theme.textTheme.bodyMedium),
+                ],
+              ),
             ),
           ),
         ],
         const SizedBox(height: 28),
         Semantics(
           label: 'You are close to an answer. Right now tracking toward ${recommendation.planLabel}.',
-          child: Container(
+          container: true,
+          child: ExcludeSemantics(
+            child: Container(
             padding: const EdgeInsets.all(22),
             decoration: BoxDecoration(
               gradient: const LinearGradient(
@@ -701,6 +706,7 @@ class _WelcomeStep extends StatelessWidget {
                 ),
               ],
             ),
+          ),
           ),
         ),
       ],
@@ -744,7 +750,9 @@ class _DevicesStep extends StatelessWidget {
             label: platformSupportsScan
                 ? 'No devices detected. The scan finished but found nothing. Add your devices manually below.'
                 : 'Network scan not available. Automatic scanning is only on macOS. Add your devices manually below.',
-            child: Container(
+            container: true,
+            child: ExcludeSemantics(
+              child: Container(
               width: double.infinity,
               padding: const EdgeInsets.all(22),
               decoration: BoxDecoration(
@@ -770,6 +778,7 @@ class _DevicesStep extends StatelessWidget {
                   ),
                 ],
               ),
+            ),
             ),
           ),
           const SizedBox(height: 16),
@@ -1253,18 +1262,21 @@ class _RecommendationConfidenceBadge extends StatelessWidget {
 
     return Semantics(
       label: 'Recommendation confidence: $label',
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.12),
-          borderRadius: BorderRadius.circular(999),
-        ),
-        child: Text(
-          label,
-          style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                color: color,
-                fontWeight: FontWeight.w700,
-              ),
+      container: true,
+      child: ExcludeSemantics(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
         ),
       ),
     );
@@ -1392,21 +1404,24 @@ class _MetricTile extends StatelessWidget {
     final theme = Theme.of(context);
     return Semantics(
       label: '$label: $value',
-      child: Container(
-        padding: const EdgeInsets.all(18),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(24),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(icon, color: const Color(0xFFE07A5F)),
-            const SizedBox(height: 12),
-            Text(label, style: theme.textTheme.bodyMedium),
-            const SizedBox(height: 4),
-            Text(value, style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700)),
-          ],
+      container: true,
+      child: ExcludeSemantics(
+        child: Container(
+          padding: const EdgeInsets.all(18),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(24),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(icon, color: const Color(0xFFE07A5F)),
+              const SizedBox(height: 12),
+              Text(label, style: theme.textTheme.bodyMedium),
+              const SizedBox(height: 4),
+              Text(value, style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700)),
+            ],
+          ),
         ),
       ),
     );
@@ -1428,6 +1443,7 @@ class _DeviceInsightCard extends StatelessWidget {
     final theme = Theme.of(context);
     return Semantics(
       label: '${device.displayName}, ${device.category.label}, ${device.connection.label}, ${_confidenceCopy(device.confidence)}',
+      container: true,
       child: Container(
         margin: const EdgeInsets.only(bottom: 16),
         padding: const EdgeInsets.all(18),
@@ -1513,18 +1529,21 @@ class _ConfidenceBadge extends StatelessWidget {
 
     return Semantics(
       label: 'Confidence: ${confidence.name}',
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        decoration: BoxDecoration(
-          color: color.withValues(alpha: 0.12),
-          borderRadius: BorderRadius.circular(999),
-        ),
-        child: Text(
-          confidence.name,
-          style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                color: color,
-                fontWeight: FontWeight.w700,
-              ),
+      container: true,
+      child: ExcludeSemantics(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(999),
+          ),
+          child: Text(
+            confidence.name,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
         ),
       ),
     );
@@ -1663,20 +1682,23 @@ class _FeatureChip extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       label: label,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(999),
-          boxShadow: const [
-            BoxShadow(
-              color: Color(0x0F000000),
-              blurRadius: 14,
-              offset: Offset(0, 4),
-            ),
-          ],
+      container: true,
+      child: ExcludeSemantics(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(999),
+            boxShadow: const [
+              BoxShadow(
+                color: Color(0x0F000000),
+                blurRadius: 14,
+                offset: Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Text(label),
         ),
-        child: Text(label),
       ),
     );
   }
@@ -1721,6 +1743,7 @@ class _QuestionCounter extends StatelessWidget {
     final theme = Theme.of(context);
     return Semantics(
       label: '$label: $value. $helper',
+      container: true,
       child: Container(
         margin: const EdgeInsets.only(bottom: 14),
         padding: const EdgeInsets.all(18),
@@ -1732,13 +1755,15 @@ class _QuestionCounter extends StatelessWidget {
         child: Row(
           children: [
             Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(label, style: theme.textTheme.titleMedium),
-                  const SizedBox(height: 4),
-                  Text(helper, style: theme.textTheme.bodyMedium?.copyWith(height: 1.45)),
-                ],
+              child: ExcludeSemantics(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(label, style: theme.textTheme.titleMedium),
+                    const SizedBox(height: 4),
+                    Text(helper, style: theme.textTheme.bodyMedium?.copyWith(height: 1.45)),
+                  ],
+                ),
               ),
             ),
             const SizedBox(width: 16),
@@ -1747,10 +1772,12 @@ class _QuestionCounter extends StatelessWidget {
               onPressed: value == 0 ? null : () => onChanged(value - 1),
               semanticsLabel: 'Decrease $label',
             ),
-            SizedBox(
-              width: 44,
-              child: Center(
-                child: Text('$value', style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+            ExcludeSemantics(
+              child: SizedBox(
+                width: 44,
+                child: Center(
+                  child: Text('$value', style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+                ),
               ),
             ),
             _CounterButton(

--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -32,6 +33,15 @@ class StreamsizeApp extends StatelessWidget {
 
     return MaterialApp(
       title: 'Streamsize',
+      debugShowCheckedModeBanner: false,
+      builder: (context, child) {
+        final mediaQuery = MediaQuery.of(context);
+        final clampedScaler = mediaQuery.textScaler.clamp(maxScaleFactor: 1.5);
+        return MediaQuery(
+          data: mediaQuery.copyWith(textScaler: clampedScaler),
+          child: child!,
+        );
+      },
       theme: baseTheme.copyWith(
         textTheme: baseTheme.textTheme.apply(bodyColor: const Color(0xFF2D2433)),
         cardTheme: const CardThemeData(
@@ -117,6 +127,16 @@ class _RecommendationFlowPageState extends State<RecommendationFlowPage> {
       _platformSupportsScan = result.platformSupportsScan;
       _isScanning = false;
       _scenario = _scenario.copyWith(devices: _allDevices);
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      // ignore: deprecated_member_use
+      SemanticsService.announce(
+        result.devices.isEmpty
+            ? 'Network scan complete. No devices found. You can add devices manually.'
+            : 'Network scan complete. ${result.devices.length} device${result.devices.length == 1 ? '' : 's'} found.',
+        TextDirection.ltr,
+      );
     });
   }
 
@@ -386,8 +406,8 @@ class _IntroPanel extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Tooltip(
-            message: 'Streamsize helps you find the right internet plan for your home.',
+          Semantics(
+            label: 'Streamsize guide: helps you find the right internet plan for your home.',
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
               decoration: BoxDecoration(
@@ -404,10 +424,11 @@ class _IntroPanel extends StatelessWidget {
               fontWeight: FontWeight.w700,
               height: 1.05,
             ),
+            semanticsLabel: 'Streamsize: find the internet plan your home actually needs.',
           ),
           const SizedBox(height: 12),
           Text(
-            'A calmer way to choose home internet: check a few visible devices, describe the busiest moments, and get a recommendation you can trust.',
+            'Answer three quick questions — check your devices, describe peak usage, and get a recommendation sized to your household.',
             style: theme.textTheme.titleMedium?.copyWith(height: 1.45),
           ),
           const SizedBox(height: 30),
@@ -449,28 +470,31 @@ class _IntroPanel extends StatelessWidget {
             _stepTitles.length,
             (index) => Padding(
               padding: const EdgeInsets.only(bottom: 14),
-              child: Row(
-                children: [
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 220),
-                    width: 34,
-                    height: 34,
-                    decoration: BoxDecoration(
-                      color: index <= stepIndex ? const Color(0xFFE07A5F) : Colors.white,
-                      borderRadius: BorderRadius.circular(999),
-                    ),
-                    alignment: Alignment.center,
-                    child: Text(
-                      '${index + 1}',
-                      style: TextStyle(
-                        color: index <= stepIndex ? Colors.white : const Color(0xFF7B7280),
-                        fontWeight: FontWeight.w700,
+              child: Semantics(
+                label: 'Step ${index + 1}: ${_stepTitles[index]}${index <= stepIndex ? ' (completed)' : ''}',
+                child: Row(
+                  children: [
+                    AnimatedContainer(
+                      duration: const Duration(milliseconds: 220),
+                      width: 34,
+                      height: 34,
+                      decoration: BoxDecoration(
+                        color: index <= stepIndex ? const Color(0xFFE07A5F) : Colors.white,
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      alignment: Alignment.center,
+                      child: Text(
+                        '${index + 1}',
+                        style: TextStyle(
+                          color: index <= stepIndex ? Colors.white : const Color(0xFF5C5468),
+                          fontWeight: FontWeight.w700,
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 12),
-                  Text(_stepTitles[index], style: theme.textTheme.titleMedium),
-                ],
+                    const SizedBox(width: 12),
+                    Text(_stepTitles[index], style: theme.textTheme.titleMedium),
+                  ],
+                ),
               ),
             ),
           ),
@@ -486,7 +510,7 @@ class _IntroPanel extends StatelessWidget {
               children: [
                 const Text(
                   'A gentle nudge',
-                  style: TextStyle(color: Color(0xFFEBDCF4)),
+                  style: TextStyle(color: Color(0xFFF0E0F8)),
                 ),
                 const SizedBox(height: 8),
                 Text(
@@ -500,7 +524,7 @@ class _IntroPanel extends StatelessWidget {
                 Text(
                   'We will show you what is truly necessary and what is just sales pressure.',
                   style: theme.textTheme.bodyLarge?.copyWith(
-                    color: const Color(0xFFEBDCF4),
+                    color: const Color(0xFFF0E0F8),
                     height: 1.45,
                   ),
                 ),
@@ -553,22 +577,28 @@ class _FlowCard extends StatelessWidget {
           Row(
             children: [
               if (onBack != null)
-                OutlinedButton(
-                  onPressed: onBack,
-                  style: OutlinedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                Semantics(
+                  label: 'Back to step $stepIndex of 4',
+                  child: OutlinedButton(
+                    onPressed: onBack,
+                    style: OutlinedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                    ),
+                    child: const Text('Back'),
                   ),
-                  child: const Text('Back'),
                 ),
               const Spacer(),
-              FilledButton(
-                onPressed: onNext,
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 18),
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+              Semantics(
+                label: isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4',
+                child: FilledButton(
+                  onPressed: onNext,
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 18),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                  ),
+                  child: Text(isLast ? 'Start over' : 'Continue'),
                 ),
-                child: Text(isLast ? 'Start over' : 'Continue'),
               ),
             ],
           ),
@@ -593,7 +623,7 @@ class _WelcomeStep extends StatelessWidget {
         Text('A simpler way to size your internet', style: theme.textTheme.headlineSmall),
         const SizedBox(height: 12),
         Text(
-          'We combine visible devices with a few easy questions about peak-time habits, then recommend a plan that feels fast without overbuying.',
+          'We will walk you through three quick steps: check what is on your network, tell us about your busiest moments, and get a plain-English recommendation.',
           style: theme.textTheme.bodyLarge?.copyWith(height: 1.5),
         ),
         const SizedBox(height: 26),
@@ -608,55 +638,61 @@ class _WelcomeStep extends StatelessWidget {
         ),
         if (isScanning) ...[
           const SizedBox(height: 20),
-          Row(
-            children: [
-              const SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              ),
-              const SizedBox(width: 10),
-              Text('Scanning your network...', style: theme.textTheme.bodyMedium),
-            ],
+          Semantics(
+            label: 'Scanning your network for devices. Please wait.',
+            child: Row(
+              children: [
+                const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 10),
+                Text('Scanning your network...', style: theme.textTheme.bodyMedium),
+              ],
+            ),
           ),
         ],
         const SizedBox(height: 28),
-        Container(
-          padding: const EdgeInsets.all(22),
-          decoration: BoxDecoration(
-            gradient: const LinearGradient(
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-              colors: [Color(0xFFFFF7F0), Color(0xFFF5EDE4)],
+        Semantics(
+          label: 'You are close to an answer. Right now tracking toward ${recommendation.planLabel}.',
+          child: Container(
+            padding: const EdgeInsets.all(22),
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [Color(0xFFFFF7F0), Color(0xFFF5EDE4)],
+              ),
+              borderRadius: BorderRadius.circular(24),
             ),
-            borderRadius: BorderRadius.circular(24),
-          ),
-          child: Row(
-            children: [
-              Container(
-                width: 58,
-                height: 58,
-                decoration: const BoxDecoration(
-                  color: Color(0xFFE07A5F),
-                  shape: BoxShape.circle,
+            child: Row(
+              children: [
+                Container(
+                  width: 58,
+                  height: 58,
+                  decoration: const BoxDecoration(
+                    color: Color(0xFFE07A5F),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(Icons.wifi_tethering_rounded, color: Colors.white),
                 ),
-                child: const Icon(Icons.wifi_tethering_rounded, color: Colors.white),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text('You are already close to an answer', style: theme.textTheme.titleMedium),
-                    const SizedBox(height: 6),
-                    Text(
-                      'Right now, your sample household is tracking toward ${recommendation.planLabel}. We will refine that over the next few screens.',
-                      style: theme.textTheme.bodyLarge?.copyWith(height: 1.45),
-                    ),
-                  ],
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('You are already close to an answer', style: theme.textTheme.titleMedium),
+                      const SizedBox(height: 6),
+                      Text(
+                        'Right now, your sample household is tracking toward ${recommendation.planLabel}. Tap Continue to refine that over the next few screens.',
+                        style: theme.textTheme.bodyLarge?.copyWith(height: 1.45),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ],
@@ -696,31 +732,36 @@ class _DevicesStep extends StatelessWidget {
         ),
         const SizedBox(height: 24),
         if (devices.isEmpty && !isScanning) ...[
-          Container(
-            width: double.infinity,
-            padding: const EdgeInsets.all(22),
-            decoration: BoxDecoration(
-              color: const Color(0xFFFFF7F0),
-              borderRadius: BorderRadius.circular(24),
-              border: Border.all(color: const Color(0xFFF0E3D8)),
-            ),
-            child: Column(
-              children: [
-                const Icon(Icons.wifi_find_rounded, size: 40, color: Color(0xFFE07A5F)),
-                const SizedBox(height: 12),
-                Text(
-                  platformSupportsScan ? 'No devices detected' : 'Network scan not available',
-                  style: theme.textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  platformSupportsScan
-                      ? 'The scan finished but found nothing. This happens on some routers with mDNS isolation. Add your devices manually below — the recommendation will still be accurate.'
-                      : 'Automatic network scanning is only available on macOS right now. Add your devices manually below — the recommendation will still be accurate.',
-                  style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
-                  textAlign: TextAlign.center,
-                ),
-              ],
+          Semantics(
+            label: platformSupportsScan
+                ? 'No devices detected. The scan finished but found nothing. Add your devices manually below.'
+                : 'Network scan not available. Automatic scanning is only on macOS. Add your devices manually below.',
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(22),
+              decoration: BoxDecoration(
+                color: const Color(0xFFFFF7F0),
+                borderRadius: BorderRadius.circular(24),
+                border: Border.all(color: const Color(0xFFF0E3D8)),
+              ),
+              child: Column(
+                children: [
+                  const Icon(Icons.wifi_find_rounded, size: 40, color: Color(0xFFE07A5F)),
+                  const SizedBox(height: 12),
+                  Text(
+                    platformSupportsScan ? 'No devices detected yet' : 'Network scan not available',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    platformSupportsScan
+                        ? 'The scan finished but found nothing. This can happen on networks with mDNS isolation. Tap "Add a device manually" below to list your devices — the recommendation will still be accurate.'
+                        : 'Automatic network scanning is available on macOS only. Tap "Add a device manually" below to list your devices — the recommendation will still be accurate.',
+                    style: theme.textTheme.bodyMedium?.copyWith(height: 1.5),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
             ),
           ),
           const SizedBox(height: 16),
@@ -786,10 +827,14 @@ class _DevicesStep extends StatelessWidget {
           ),
         ],
         // "Add manually" text link — macOS-native feel; FABs are mobile-native.
-        TextButton.icon(
-          onPressed: onAddDeviceManually,
-          icon: const Icon(Icons.add_circle_outline_rounded, size: 18),
-          label: const Text('Add a device manually'),
+        Semantics(
+          label: 'Add a device that the scan may have missed',
+          button: true,
+          child: TextButton.icon(
+            onPressed: onAddDeviceManually,
+            icon: const Icon(Icons.add_circle_outline_rounded, size: 18),
+            label: const Text('Add a device manually'),
+          ),
         ),
       ],
     );
@@ -959,13 +1004,16 @@ class _ResultsStep extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text('Your right-sized plan', style: theme.textTheme.headlineSmall),
-            ),
-            _RecommendationConfidenceBadge(confidence: recommendation.confidence),
-          ],
+        Semantics(
+          label: 'Your right-sized plan: ${recommendation.downloadMbps} Mbps download, ${recommendation.uploadMbps} Mbps upload. ${recommendation.planLabel}.',
+          child: Row(
+            children: [
+              Expanded(
+                child: Text('Your right-sized plan', style: theme.textTheme.headlineSmall),
+              ),
+              _RecommendationConfidenceBadge(confidence: recommendation.confidence),
+            ],
+          ),
         ),
         if (recommendation.confidence == ConfidenceScore.low) ...[
           const SizedBox(height: 8),
@@ -1029,7 +1077,7 @@ class _ResultsStep extends StatelessWidget {
                     padding: const EdgeInsets.only(bottom: 10),
                     child: Text(
                       'Mbps',
-                      style: theme.textTheme.headlineSmall?.copyWith(color: const Color(0xFFEBDCF4)),
+                      style: theme.textTheme.headlineSmall?.copyWith(color: const Color(0xFFF0E0F8)),
                     ),
                   ),
                 ],
@@ -1045,7 +1093,7 @@ class _ResultsStep extends StatelessWidget {
                     ? 'This should comfortably cover ${scenario.simultaneous4kStreams} 4K streams, ${scenario.simultaneousVideoCalls} live calls, and everyday browsing without paying for a premium tier you are unlikely to feel.'
                     : 'Your peak-time habits suggest a faster tier is justified so the busiest moments still feel smooth.',
                 style: theme.textTheme.bodyLarge?.copyWith(
-                  color: const Color(0xFFEBDCF4),
+                  color: const Color(0xFFF0E0F8),
                   height: 1.5,
                 ),
               ),
@@ -1055,7 +1103,10 @@ class _ResultsStep extends StatelessWidget {
                 runSpacing: 12,
                 children: [
                   _DarkStatPill(label: 'Upload ${recommendation.uploadMbps} Mbps'),
-                  _DarkStatPill(label: 'Confidence ${recommendation.confidence.name}'),
+                  Semantics(
+                    label: 'Confidence: ${recommendation.confidence.name}',
+                    child: _DarkStatPill(label: 'Confidence ${recommendation.confidence.name}'),
+                  ),
                   _DarkStatPill(label: '${scenario.devices.length} devices considered'),
                 ],
               ),
@@ -1066,7 +1117,7 @@ class _ResultsStep extends StatelessWidget {
         // Speed test section
         _SpotlightCard(
           title: 'Compare with your actual speed',
-          subtitle: 'Optional: run a quick test to see how your current plan compares to our recommendation.',
+          subtitle: 'Optional — run a quick test to see how your current plan compares to our recommendation.',
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -1187,18 +1238,21 @@ class _RecommendationConfidenceBadge extends StatelessWidget {
       ConfidenceScore.low => ('Rough estimate', const Color(0xFFC26A5A)),
     };
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-              color: color,
-              fontWeight: FontWeight.w700,
-            ),
+    return Semantics(
+      label: 'Recommendation confidence: $label',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Text(
+          label,
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w700,
+              ),
+        ),
       ),
     );
   }
@@ -1278,27 +1332,30 @@ class _ProgressHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text('Step ${stepIndex + 1} of 4', style: Theme.of(context).textTheme.labelLarge),
-        const SizedBox(height: 12),
-        Row(
-          children: List.generate(
-            4,
-            (index) => Expanded(
-              child: Container(
-                margin: EdgeInsets.only(right: index == 3 ? 0 : 10),
-                height: 8,
-                decoration: BoxDecoration(
-                  color: index <= stepIndex ? const Color(0xFFE07A5F) : const Color(0xFFEFE4D7),
-                  borderRadius: BorderRadius.circular(999),
+    return Semantics(
+      label: 'Step ${stepIndex + 1} of 4',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Step ${stepIndex + 1} of 4', style: Theme.of(context).textTheme.labelLarge),
+          const SizedBox(height: 12),
+          Row(
+            children: List.generate(
+              4,
+              (index) => Expanded(
+                child: Container(
+                  margin: EdgeInsets.only(right: index == 3 ? 0 : 10),
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: index <= stepIndex ? const Color(0xFFE07A5F) : const Color(0xFFEFE4D7),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }
@@ -1317,21 +1374,24 @@ class _MetricTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.all(18),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(24),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(icon, color: const Color(0xFFE07A5F)),
-          const SizedBox(height: 12),
-          Text(label, style: theme.textTheme.bodyMedium),
-          const SizedBox(height: 4),
-          Text(value, style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700)),
-        ],
+    return Semantics(
+      label: '$label: $value',
+      child: Container(
+        padding: const EdgeInsets.all(18),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(24),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, color: const Color(0xFFE07A5F), semanticLabel: label),
+            const SizedBox(height: 12),
+            Text(label, style: theme.textTheme.bodyMedium),
+            const SizedBox(height: 4),
+            Text(value, style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700)),
+          ],
+        ),
       ),
     );
   }
@@ -1350,70 +1410,73 @@ class _DeviceInsightCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      padding: const EdgeInsets.all(18),
-      decoration: BoxDecoration(
-        color: const Color(0xFFFFFBF8),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: const Color(0xFFF0E3D8)),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x0A000000),
-            blurRadius: 12,
-            offset: Offset(0, 4),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              _CategoryIcon(category: device.category, large: true),
-              const SizedBox(width: 14),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(device.displayName, style: theme.textTheme.titleMedium),
-                    const SizedBox(height: 4),
-                    Text(_deviceNarrative(device), style: theme.textTheme.bodyMedium?.copyWith(height: 1.4)),
-                  ],
-                ),
-              ),
-              _ConfidenceBadge(confidence: device.confidence),
-            ],
-          ),
-          const SizedBox(height: 16),
-          Wrap(
-            spacing: 10,
-            runSpacing: 10,
-            children: [
-              _MiniInfoPill(icon: Icons.wifi_rounded, label: device.connection.label),
-              _MiniInfoPill(icon: Icons.category_rounded, label: device.category.label),
-              _MiniInfoPill(icon: Icons.insights_rounded, label: _confidenceCopy(device.confidence)),
-            ],
-          ),
-          const SizedBox(height: 16),
-          DropdownButtonFormField<DeviceCategory>(
-            initialValue: device.category,
-            decoration: const InputDecoration(labelText: 'Looks more like'),
-            items: DeviceCategory.values
-                .map(
-                  (category) => DropdownMenuItem(
-                    value: category,
-                    child: Text(category.label),
+    return Semantics(
+      label: '${device.displayName}, ${device.category.label}, ${device.connection.label}, ${_confidenceCopy(device.confidence)}',
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 16),
+        padding: const EdgeInsets.all(18),
+        decoration: BoxDecoration(
+          color: const Color(0xFFFFFBF8),
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(color: const Color(0xFFF0E3D8)),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x0A000000),
+              blurRadius: 12,
+              offset: Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                _CategoryIcon(category: device.category, large: true),
+                const SizedBox(width: 14),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(device.displayName, style: theme.textTheme.titleMedium),
+                      const SizedBox(height: 4),
+                      Text(_deviceNarrative(device), style: theme.textTheme.bodyMedium?.copyWith(height: 1.4)),
+                    ],
                   ),
-                )
-                .toList(),
-            onChanged: (value) {
-              if (value != null) {
-                onCategoryChanged(value);
-              }
-            },
-          ),
-        ],
+                ),
+                _ConfidenceBadge(confidence: device.confidence),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                _MiniInfoPill(icon: Icons.wifi_rounded, label: device.connection.label),
+                _MiniInfoPill(icon: Icons.category_rounded, label: device.category.label),
+                _MiniInfoPill(icon: Icons.insights_rounded, label: _confidenceCopy(device.confidence)),
+              ],
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<DeviceCategory>(
+              initialValue: device.category,
+              decoration: const InputDecoration(labelText: 'Looks more like'),
+              items: DeviceCategory.values
+                  .map(
+                    (category) => DropdownMenuItem(
+                      value: category,
+                      child: Text(category.label),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (value) {
+                if (value != null) {
+                  onCategoryChanged(value);
+                }
+              },
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -1432,18 +1495,21 @@ class _ConfidenceBadge extends StatelessWidget {
       ConfidenceScore.low => const Color(0xFFC26A5A),
     };
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Text(
-        confidence.name,
-        style: Theme.of(context).textTheme.labelLarge?.copyWith(
-              color: color,
-              fontWeight: FontWeight.w700,
-            ),
+    return Semantics(
+      label: 'Confidence: ${confidence.name}',
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Text(
+          confidence.name,
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w700,
+              ),
+        ),
       ),
     );
   }
@@ -1579,20 +1645,23 @@ class _FeatureChip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(999),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x0F000000),
-            blurRadius: 14,
-            offset: Offset(0, 4),
-          ),
-        ],
+    return Semantics(
+      label: label,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(999),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x0F000000),
+              blurRadius: 14,
+              offset: Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Text(label),
       ),
-      child: Text(label),
     );
   }
 }
@@ -1634,65 +1703,78 @@ class _QuestionCounter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      margin: const EdgeInsets.only(bottom: 14),
-      padding: const EdgeInsets.all(18),
-      decoration: BoxDecoration(
-        color: const Color(0xFFFFFBF8),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: const Color(0xFFF0E3D8)),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(label, style: theme.textTheme.titleMedium),
-                const SizedBox(height: 4),
-                Text(helper, style: theme.textTheme.bodyMedium?.copyWith(height: 1.45)),
-              ],
+    return Semantics(
+      label: '$label: $value. $helper',
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 14),
+        padding: const EdgeInsets.all(18),
+        decoration: BoxDecoration(
+          color: const Color(0xFFFFFBF8),
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(color: const Color(0xFFF0E3D8)),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(label, style: theme.textTheme.titleMedium),
+                  const SizedBox(height: 4),
+                  Text(helper, style: theme.textTheme.bodyMedium?.copyWith(height: 1.45)),
+                ],
+              ),
             ),
-          ),
-          const SizedBox(width: 16),
-          _CounterButton(
-            icon: Icons.remove_rounded,
-            onPressed: value == 0 ? null : () => onChanged(value - 1),
-          ),
-          SizedBox(
-            width: 44,
-            child: Center(child: Text('$value', style: theme.textTheme.titleMedium)),
-          ),
-          _CounterButton(
-            icon: Icons.add_rounded,
-            onPressed: () => onChanged(value + 1),
-          ),
-        ],
+            const SizedBox(width: 16),
+            _CounterButton(
+              icon: Icons.remove_rounded,
+              onPressed: value == 0 ? null : () => onChanged(value - 1),
+              semanticsLabel: 'Decrease $label',
+            ),
+            SizedBox(
+              width: 44,
+              child: Center(
+                child: Text('$value', style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+              ),
+            ),
+            _CounterButton(
+              icon: Icons.add_rounded,
+              onPressed: () => onChanged(value + 1),
+              semanticsLabel: 'Increase $label',
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
 class _CounterButton extends StatelessWidget {
-  const _CounterButton({required this.icon, this.onPressed});
+  const _CounterButton({required this.icon, this.onPressed, this.semanticsLabel});
 
   final IconData icon;
   final VoidCallback? onPressed;
+  final String? semanticsLabel;
 
   @override
   Widget build(BuildContext context) {
     final disabled = onPressed == null;
-    return InkWell(
-      onTap: onPressed,
-      borderRadius: BorderRadius.circular(16),
-      child: Ink(
-        width: 40,
-        height: 40,
-        decoration: BoxDecoration(
-          color: disabled ? const Color(0xFFF2E6D9) : const Color(0xFFF3E7D8),
-          borderRadius: BorderRadius.circular(16),
+    return Semantics(
+      label: semanticsLabel,
+      button: true,
+      enabled: onPressed != null,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(16),
+        child: Ink(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: disabled ? const Color(0xFFF2E6D9) : const Color(0xFFF3E7D8),
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Icon(icon, color: disabled ? const Color(0xFFB9A99B) : const Color(0xFFE07A5F)),
         ),
-        child: Icon(icon, color: disabled ? const Color(0xFFB9A99B) : const Color(0xFFE07A5F)),
       ),
     );
   }

--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -34,14 +34,6 @@ class StreamsizeApp extends StatelessWidget {
     return MaterialApp(
       title: 'Streamsize',
       debugShowCheckedModeBanner: false,
-      builder: (context, child) {
-        final mediaQuery = MediaQuery.of(context);
-        final clampedScaler = mediaQuery.textScaler.clamp(maxScaleFactor: 1.5);
-        return MediaQuery(
-          data: mediaQuery.copyWith(textScaler: clampedScaler),
-          child: child ?? const SizedBox.shrink(),
-        );
-      },
       theme: baseTheme.copyWith(
         textTheme: baseTheme.textTheme.apply(bodyColor: const Color(0xFF2D2433)),
         cardTheme: const CardThemeData(
@@ -130,6 +122,7 @@ class _RecommendationFlowPageState extends State<RecommendationFlowPage> {
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      if (!WidgetsBinding.instance.semanticsEnabled) return;
       // ignore: deprecated_member_use
       SemanticsService.announce(
         result.devices.isEmpty
@@ -472,6 +465,8 @@ class _IntroPanel extends StatelessWidget {
               padding: const EdgeInsets.only(bottom: 14),
               child: Semantics(
                 label: 'Step ${index + 1}: ${_stepTitles[index]}${index < stepIndex ? ' (completed)' : index == stepIndex ? ' (current)' : ''}',
+                container: true,
+                excludeSemantics: true,
                 child: Row(
                   children: [
                     AnimatedContainer(
@@ -579,6 +574,8 @@ class _FlowCard extends StatelessWidget {
               if (onBack != null)
                 Semantics(
                   label: 'Back to step $stepIndex of 4',
+                  container: true,
+                  excludeSemantics: true,
                   child: OutlinedButton(
                     onPressed: onBack,
                     style: OutlinedButton.styleFrom(
@@ -591,6 +588,8 @@ class _FlowCard extends StatelessWidget {
               const Spacer(),
               Semantics(
                 label: isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4',
+                container: true,
+                excludeSemantics: true,
                 child: FilledButton(
                   onPressed: onNext,
                   style: FilledButton.styleFrom(
@@ -830,6 +829,8 @@ class _DevicesStep extends StatelessWidget {
         Semantics(
           label: 'Add a device that the scan may have missed',
           button: true,
+          container: true,
+          excludeSemantics: true,
           child: TextButton.icon(
             onPressed: onAddDeviceManually,
             icon: const Icon(Icons.add_circle_outline_rounded, size: 18),
@@ -1334,6 +1335,8 @@ class _ProgressHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       label: 'Step ${stepIndex + 1} of 4',
+      container: true,
+      excludeSemantics: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -1385,7 +1388,7 @@ class _MetricTile extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(icon, color: const Color(0xFFE07A5F), semanticLabel: label),
+            Icon(icon, color: const Color(0xFFE07A5F)),
             const SizedBox(height: 12),
             Text(label, style: theme.textTheme.bodyMedium),
             const SizedBox(height: 4),

--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -1028,13 +1028,16 @@ class _ResultsStep extends StatelessWidget {
       children: [
         Semantics(
           label: 'Your right-sized plan: ${recommendation.downloadMbps} Mbps download, ${recommendation.uploadMbps} Mbps upload. ${recommendation.planLabel}.',
-          child: Row(
-            children: [
-              Expanded(
-                child: Text('Your right-sized plan', style: theme.textTheme.headlineSmall),
-              ),
-              _RecommendationConfidenceBadge(confidence: recommendation.confidence),
-            ],
+          container: true,
+          child: ExcludeSemantics(
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text('Your right-sized plan', style: theme.textTheme.headlineSmall),
+                ),
+                _RecommendationConfidenceBadge(confidence: recommendation.confidence),
+              ],
+            ),
           ),
         ),
         if (recommendation.confidence == ConfidenceScore.low) ...[
@@ -1127,7 +1130,10 @@ class _ResultsStep extends StatelessWidget {
                   _DarkStatPill(label: 'Upload ${recommendation.uploadMbps} Mbps'),
                   Semantics(
                     label: 'Confidence: ${recommendation.confidence.name}',
-                    child: _DarkStatPill(label: 'Confidence ${recommendation.confidence.name}'),
+                    container: true,
+                    child: ExcludeSemantics(
+                      child: _DarkStatPill(label: 'Confidence ${recommendation.confidence.name}'),
+                    ),
                   ),
                   _DarkStatPill(label: '${scenario.devices.length} devices considered'),
                 ],

--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -39,7 +39,7 @@ class StreamsizeApp extends StatelessWidget {
         final clampedScaler = mediaQuery.textScaler.clamp(maxScaleFactor: 1.5);
         return MediaQuery(
           data: mediaQuery.copyWith(textScaler: clampedScaler),
-          child: child!,
+          child: child ?? const SizedBox.shrink(),
         );
       },
       theme: baseTheme.copyWith(
@@ -135,7 +135,7 @@ class _RecommendationFlowPageState extends State<RecommendationFlowPage> {
         result.devices.isEmpty
             ? 'Network scan complete. No devices found. You can add devices manually.'
             : 'Network scan complete. ${result.devices.length} device${result.devices.length == 1 ? '' : 's'} found.',
-        TextDirection.ltr,
+        Directionality.of(context),
       );
     });
   }
@@ -471,7 +471,7 @@ class _IntroPanel extends StatelessWidget {
             (index) => Padding(
               padding: const EdgeInsets.only(bottom: 14),
               child: Semantics(
-                label: 'Step ${index + 1}: ${_stepTitles[index]}${index <= stepIndex ? ' (completed)' : ''}',
+                label: 'Step ${index + 1}: ${_stepTitles[index]}${index < stepIndex ? ' (completed)' : index == stepIndex ? ' (current)' : ''}',
                 child: Row(
                   children: [
                     AnimatedContainer(
@@ -749,7 +749,7 @@ class _DevicesStep extends StatelessWidget {
                   const Icon(Icons.wifi_find_rounded, size: 40, color: Color(0xFFE07A5F)),
                   const SizedBox(height: 12),
                   Text(
-                    platformSupportsScan ? 'No devices detected yet' : 'Network scan not available',
+                    platformSupportsScan ? 'No devices detected' : 'Network scan not available',
                     style: theme.textTheme.titleMedium,
                   ),
                   const SizedBox(height: 8),

--- a/apps/client_flutter/lib/main.dart
+++ b/apps/client_flutter/lib/main.dart
@@ -466,7 +466,6 @@ class _IntroPanel extends StatelessWidget {
               child: Semantics(
                 label: 'Step ${index + 1}: ${_stepTitles[index]}${index < stepIndex ? ' (completed)' : index == stepIndex ? ' (current)' : ''}',
                 container: true,
-                excludeSemantics: true,
                 child: Row(
                   children: [
                     AnimatedContainer(
@@ -572,31 +571,33 @@ class _FlowCard extends StatelessWidget {
           Row(
             children: [
               if (onBack != null)
-                Semantics(
-                  label: 'Back to step $stepIndex of 4',
-                  container: true,
-                  excludeSemantics: true,
+                Tooltip(
+                  message: 'Back to step $stepIndex of 4',
                   child: OutlinedButton(
                     onPressed: onBack,
                     style: OutlinedButton.styleFrom(
                       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
                       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
                     ),
-                    child: const Text('Back'),
+                    child: Semantics(
+                      label: 'Back to step $stepIndex of 4',
+                      child: const Text('Back'),
+                    ),
                   ),
                 ),
               const Spacer(),
-              Semantics(
-                label: isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4',
-                container: true,
-                excludeSemantics: true,
+              Tooltip(
+                message: isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4',
                 child: FilledButton(
                   onPressed: onNext,
                   style: FilledButton.styleFrom(
                     padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 18),
                     shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
                   ),
-                  child: Text(isLast ? 'Start over' : 'Continue'),
+                  child: Semantics(
+                    label: isLast ? 'Start over from the beginning' : 'Continue to step ${stepIndex + 2} of 4',
+                    child: Text(isLast ? 'Start over' : 'Continue'),
+                  ),
                 ),
               ),
             ],
@@ -826,15 +827,15 @@ class _DevicesStep extends StatelessWidget {
           ),
         ],
         // "Add manually" text link — macOS-native feel; FABs are mobile-native.
-        Semantics(
-          label: 'Add a device that the scan may have missed',
-          button: true,
-          container: true,
-          excludeSemantics: true,
+        Tooltip(
+          message: 'Add a device that the scan may have missed',
           child: TextButton.icon(
             onPressed: onAddDeviceManually,
             icon: const Icon(Icons.add_circle_outline_rounded, size: 18),
-            label: const Text('Add a device manually'),
+            label: Semantics(
+              label: 'Add a device that the scan may have missed',
+              child: const Text('Add a device manually'),
+            ),
           ),
         ),
       ],
@@ -1336,7 +1337,6 @@ class _ProgressHeader extends StatelessWidget {
     return Semantics(
       label: 'Step ${stepIndex + 1} of 4',
       container: true,
-      excludeSemantics: true,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/apps/client_flutter/lib/widgets/add_device_modal.dart
+++ b/apps/client_flutter/lib/widgets/add_device_modal.dart
@@ -82,6 +82,7 @@ class _AddDeviceSheetState extends State<_AddDeviceSheet> {
               hintText: 'e.g. Office NAS, Kids iPad',
             ),
             textCapitalization: TextCapitalization.words,
+            autofocus: true,
           ),
           const SizedBox(height: 16),
           DropdownButtonFormField<DeviceCategory>(


### PR DESCRIPTION
Adds accessibility and onboarding polish for the v0.1 MVP release.

Closes #5

## Changes
- **Keyboard navigation / Semantics**: Added Semantics wrappers with descriptive labels to all interactive and informational widgets (step indicators, counter buttons, metric tiles, confidence badges, progress headers, feature chips, device cards, empty-state panel, result header). Icons include semanticLabel. Scan completion announces via SemanticsService (guarded by semanticsEnabled).
- **Readable contrast**: Darkened low-contrast text (inactive step numbers 7B7280→5C5468, dark panel text EBDCF4→F0E0F8) for WCAG AA compliance.
- **Clearer onboarding language**: Rewrote welcome step and intro panel copy to be more actionable. Added semanticsLabel on headlines. Changed passive phrasing to direct calls-to-action.
- **Better empty/edge states**: Empty device state has clearer guidance with tap-friendly instructions. Add-device modal auto-focuses the name field.
- **No duplicate announcements**: Used ExcludeSemantics inside Semantics containers to prevent screen readers from announcing both the synthesized label and visible text. Tooltip+Semantics labels share a single string variable to avoid drift.